### PR TITLE
[dingo-exec] Fixed #5: Add execution statistics and push them up when…

### DIFF
--- a/.idea/codeStyles/Project.xml
+++ b/.idea/codeStyles/Project.xml
@@ -2,6 +2,18 @@
   <code_scheme name="Project" version="173">
     <JavaCodeStyleSettings>
       <option name="CLASS_COUNT_TO_USE_IMPORT_ON_DEMAND" value="99" />
+      <option name="NAMES_COUNT_TO_USE_IMPORT_ON_DEMAND" value="99" />
+      <option name="IMPORT_LAYOUT_TABLE">
+        <value>
+          <package name="" withSubpackages="true" static="false" />
+          <emptyLine />
+          <package name="java" withSubpackages="true" static="false" />
+          <package name="javax" withSubpackages="true" static="false" />
+          <emptyLine />
+          <package name="" withSubpackages="true" static="true" />
+        </value>
+      </option>
+      <option name="JD_INDENT_ON_CONTINUATION" value="true" />
     </JavaCodeStyleSettings>
   </code_scheme>
 </component>

--- a/.idea/codeStyles/codeStyleConfig.xml
+++ b/.idea/codeStyles/codeStyleConfig.xml
@@ -1,5 +1,5 @@
 <component name="ProjectCodeStyleConfiguration">
   <state>
-    <option name="PREFERRED_PROJECT_CODE_STYLE" value="Default" />
+    <option name="USE_PER_PROJECT_SETTINGS" value="true" />
   </state>
 </component>

--- a/dingo-calcite/src/main/java/io/dingodb/calcite/JobRunner.java
+++ b/dingo-calcite/src/main/java/io/dingodb/calcite/JobRunner.java
@@ -33,7 +33,6 @@ import org.apache.calcite.linq4j.Enumerable;
 import org.apache.calcite.linq4j.Enumerator;
 import org.apache.calcite.linq4j.Linq4j;
 
-import java.nio.charset.StandardCharsets;
 import javax.annotation.Nonnull;
 
 @Slf4j
@@ -45,7 +44,7 @@ public final class JobRunner {
     @Nonnull
     public static Enumerable<Object[]> run(String serializedJob) {
         try {
-            final Job job = JobImpl.deserialize(serializedJob);
+            final Job job = JobImpl.fromString(serializedJob);
             final JobRunner runner = new JobRunner(job);
             return new AbstractEnumerable<Object[]>() {
                 @Override
@@ -62,7 +61,7 @@ public final class JobRunner {
     @Nonnull
     public static Enumerable<Object> runOneColumn(String serializedJob) {
         try {
-            final Job job = JobImpl.deserialize(serializedJob);
+            final Job job = JobImpl.fromString(serializedJob);
             final JobRunner runner = new JobRunner(job);
             return new AbstractEnumerable<Object>() {
                 @Override
@@ -107,12 +106,11 @@ public final class JobRunner {
             }
             Location location = task.getLocation();
             if (!location.equals(Services.META.currentLocation())) {
-                task.serialize();
                 try {
                     Channel channel = Services.openNewSysChannel(location.getHost(), location.getPort());
                     Message msg = SimpleMessage.builder()
                         .tag(SimpleTag.TASK_TAG)
-                        .content(task.serialize().getBytes(StandardCharsets.UTF_8))
+                        .content(task.serialize())
                         .build();
                     channel.send(msg);
                     channel.close();

--- a/dingo-calcite/src/main/java/io/dingodb/calcite/RootEnumerator.java
+++ b/dingo-calcite/src/main/java/io/dingodb/calcite/RootEnumerator.java
@@ -16,13 +16,13 @@
 
 package io.dingodb.calcite;
 
-import io.dingodb.exec.operator.AbstractOperator;
 import io.dingodb.exec.operator.RootOperator;
 import org.apache.calcite.linq4j.Enumerator;
 
 import javax.annotation.Nonnull;
 
 public class RootEnumerator implements Enumerator<Object[]> {
+
     private final RootOperator root;
     private Object[] current;
 
@@ -38,7 +38,7 @@ public class RootEnumerator implements Enumerator<Object[]> {
     @Override
     public boolean moveNext() {
         current = root.popValue();
-        return current != AbstractOperator.FIN;
+        return current != RootOperator.FIN;
     }
 
     @Override

--- a/dingo-calcite/src/main/java/io/dingodb/calcite/rel/EnumerableRoot.java
+++ b/dingo-calcite/src/main/java/io/dingodb/calcite/rel/EnumerableRoot.java
@@ -64,7 +64,7 @@ public final class EnumerableRoot extends SingleRel implements EnumerableRel {
             return implementor.result(
                 physType,
                 Blocks.toBlock(
-                    Expressions.call(method, Expressions.constant(job.serialize()))
+                    Expressions.call(method, Expressions.constant(job.toString()))
                 )
             );
         } catch (NoSuchMethodException e) {

--- a/dingo-calcite/src/main/java/io/dingodb/calcite/rule/DingoGetByKeysRule.java
+++ b/dingo-calcite/src/main/java/io/dingodb/calcite/rule/DingoGetByKeysRule.java
@@ -44,7 +44,7 @@ public class DingoGetByKeysRule extends RelRule<DingoGetByKeysRule.Config> {
      *
      * @param keyTuples key tuples to be checked
      * @return <code>true</code> means the primary columns are all set for each row
-     *     <code>false</code> means some columns are not set for any row, so full scan is needed
+     * <code>false</code> means some columns are not set for any row, so full scan is needed
      */
     private static boolean checkKeyTuples(Set<Object[]> keyTuples) {
         if (keyTuples == null) {

--- a/dingo-cli/src/main/java/io/dingodb/cli/handler/CsvBatchHandler.java
+++ b/dingo-cli/src/main/java/io/dingodb/cli/handler/CsvBatchHandler.java
@@ -56,7 +56,7 @@ public class CsvBatchHandler {
         executor = new ScheduledThreadPoolExecutor(parallel);
         CSVParser csvParser = CSVParser.parse(new FileReader(fileName), CSVFormat.DEFAULT.withFirstRecordAsHeader());
         List<String> headers = csvParser.getHeaderNames();
-        String headersJson = JSON.serialize(headers);
+        String headersJson = JSON.stringify(headers);
         String insert = String.format("insert into %s(%s)", table, headersJson.substring(1, headersJson.length() - 2))
             .replaceAll("\"", "");
         init();
@@ -111,7 +111,7 @@ public class CsvBatchHandler {
 
     private static String valuesSql(List<String> headers, CSVRecord record) {
         try {
-            String valuesJson = JSON.serialize(headers.stream().map(record::get).collect(Collectors.toList()));
+            String valuesJson = JSON.stringify(headers.stream().map(record::get).collect(Collectors.toList()));
             return String.format("(%s)", valuesJson.substring(1, valuesJson.length() - 2)).replaceAll("\"", "'");
         } catch (JsonProcessingException e) {
             e.printStackTrace();

--- a/dingo-common/src/main/java/io/dingodb/common/table/TableDefinition.java
+++ b/dingo-common/src/main/java/io/dingodb/common/table/TableDefinition.java
@@ -182,7 +182,7 @@ public class TableDefinition {
     }
 
     public String toJson() throws JsonProcessingException {
-        return PARSER.serialize(this);
+        return PARSER.stringify(this);
     }
 
     public void writeJson(OutputStream os) throws IOException {

--- a/dingo-exec/src/main/java/io/dingodb/exec/base/Job.java
+++ b/dingo-exec/src/main/java/io/dingodb/exec/base/Job.java
@@ -39,6 +39,4 @@ public interface Job {
     default boolean isEmpty() {
         return getTasks().isEmpty();
     }
-
-    String serialize();
 }

--- a/dingo-exec/src/main/java/io/dingodb/exec/base/Operator.java
+++ b/dingo-exec/src/main/java/io/dingodb/exec/base/Operator.java
@@ -16,6 +16,8 @@
 
 package io.dingodb.exec.base;
 
+import io.dingodb.exec.fin.Fin;
+
 import java.util.List;
 
 import static io.dingodb.common.util.Utils.sole;
@@ -45,6 +47,8 @@ public interface Operator {
      * @return `true` means another push needed, `false` means the task is canceled or finished
      */
     boolean push(int pin, Object[] tuple);
+
+    void fin(int pin, Fin fin);
 
     default Input getInput(int pin) {
         Input input = new Input(getId(), pin);

--- a/dingo-exec/src/main/java/io/dingodb/exec/base/Output.java
+++ b/dingo-exec/src/main/java/io/dingodb/exec/base/Output.java
@@ -16,6 +16,7 @@
 
 package io.dingodb.exec.base;
 
+import io.dingodb.exec.fin.Fin;
 import io.dingodb.net.Location;
 
 import javax.annotation.Nonnull;
@@ -32,6 +33,11 @@ public interface Output {
     default boolean push(Object[] tuple) {
         Input link = getLink();
         return link.getOperator().push(link.getPin(), tuple);
+    }
+
+    default void pushFin(Fin fin) {
+        Input link = getLink();
+        link.getOperator().fin(link.getPin(), fin);
     }
 
     default Task getTask() {

--- a/dingo-exec/src/main/java/io/dingodb/exec/base/Task.java
+++ b/dingo-exec/src/main/java/io/dingodb/exec/base/Task.java
@@ -65,5 +65,5 @@ public interface Task {
         return getOperators().get(id);
     }
 
-    String serialize();
+    byte[] serialize();
 }

--- a/dingo-exec/src/main/java/io/dingodb/exec/codec/AvroTxRxCodec.java
+++ b/dingo-exec/src/main/java/io/dingodb/exec/codec/AvroTxRxCodec.java
@@ -1,0 +1,69 @@
+/*
+ * Copyright 2021 DataCanvas
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package io.dingodb.exec.codec;
+
+import io.dingodb.common.codec.AvroCodec;
+import io.dingodb.common.table.TupleSchema;
+import io.dingodb.exec.fin.Fin;
+import io.dingodb.exec.fin.FinWithProfiles;
+
+import java.io.ByteArrayInputStream;
+import java.io.ByteArrayOutputStream;
+import java.io.IOException;
+import javax.annotation.Nonnull;
+
+public final class AvroTxRxCodec implements TxRxCodec {
+    public static final int FIN_FLAG = 0;
+    public static final int TUPLE_FLAG = 1;
+
+    private final AvroCodec avroCodec;
+
+    public AvroTxRxCodec(@Nonnull TupleSchema schema) {
+        this.avroCodec = new AvroCodec(schema.getAvroSchema());
+    }
+
+    @Nonnull
+    @Override
+    public byte[] encode(Object[] tuple) throws IOException {
+        ByteArrayOutputStream os = new ByteArrayOutputStream();
+        os.write(TUPLE_FLAG);
+        avroCodec.encode(os, tuple);
+        return os.toByteArray();
+    }
+
+    @Nonnull
+    public byte[] encodeFin(@Nonnull Fin fin) throws IOException {
+        ByteArrayOutputStream os = new ByteArrayOutputStream();
+        os.write(FIN_FLAG);
+        fin.writeStream(os);
+        return os.toByteArray();
+    }
+
+    @Override
+    public Object[] decode(byte[] bytes) throws IOException {
+        ByteArrayInputStream is = new ByteArrayInputStream(bytes);
+        int flag = is.read();
+        switch (flag) {
+            case TUPLE_FLAG:
+                return avroCodec.decode(is);
+            case FIN_FLAG:
+                return new Object[]{FinWithProfiles.deserialize(is)};
+            default:
+        }
+        throw new IllegalStateException("Unexpected data message flag \"" + flag + "\".");
+    }
+}

--- a/dingo-exec/src/main/java/io/dingodb/exec/codec/TxRxCodec.java
+++ b/dingo-exec/src/main/java/io/dingodb/exec/codec/TxRxCodec.java
@@ -1,0 +1,29 @@
+/*
+ * Copyright 2021 DataCanvas
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package io.dingodb.exec.codec;
+
+import io.dingodb.exec.fin.Fin;
+
+import java.io.IOException;
+
+public interface TxRxCodec {
+    byte[] encode(Object[] tuple) throws IOException;
+
+    byte[] encodeFin(Fin fin) throws IOException;
+
+    Object[] decode(byte[] bytes) throws IOException;
+}

--- a/dingo-exec/src/main/java/io/dingodb/exec/fin/Fin.java
+++ b/dingo-exec/src/main/java/io/dingodb/exec/fin/Fin.java
@@ -1,0 +1,26 @@
+/*
+ * Copyright 2021 DataCanvas
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package io.dingodb.exec.fin;
+
+import java.io.IOException;
+import java.io.OutputStream;
+
+public interface Fin {
+    void writeStream(OutputStream os) throws IOException;
+
+    String detail();
+}

--- a/dingo-exec/src/main/java/io/dingodb/exec/fin/FinWithProfiles.java
+++ b/dingo-exec/src/main/java/io/dingodb/exec/fin/FinWithProfiles.java
@@ -1,0 +1,77 @@
+/*
+ * Copyright 2021 DataCanvas
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package io.dingodb.exec.fin;
+
+import com.fasterxml.jackson.annotation.JsonCreator;
+import com.fasterxml.jackson.annotation.JsonValue;
+import com.fasterxml.jackson.core.JsonProcessingException;
+import io.dingodb.expr.json.runtime.Parser;
+import lombok.Getter;
+
+import java.io.ByteArrayInputStream;
+import java.io.IOException;
+import java.io.OutputStream;
+import java.util.LinkedList;
+import java.util.List;
+import javax.annotation.Nonnull;
+
+public class FinWithProfiles implements Fin {
+    public static final Parser PARSER = Parser.JSON;
+
+    @Getter
+    @JsonValue
+    List<OperatorProfile> profiles;
+
+    @JsonCreator
+    public FinWithProfiles(List<OperatorProfile> profiles) {
+        this.profiles = profiles;
+    }
+
+    public static FinWithProfiles deserialize(ByteArrayInputStream is) throws IOException {
+        return PARSER.parse(is, FinWithProfiles.class);
+    }
+
+    @Nonnull
+    public static FinWithProfiles of(OperatorProfile profile) {
+        List<OperatorProfile> profiles = new LinkedList<>();
+        profiles.add(profile);
+        return new FinWithProfiles(profiles);
+    }
+
+    @Override
+    public void writeStream(@Nonnull OutputStream os) throws IOException {
+        PARSER.writeStream(os, this);
+    }
+
+    @Override
+    public String detail() {
+        StringBuilder builder = new StringBuilder();
+        for (OperatorProfile profile : profiles) {
+            builder.append(profile.detail()).append("\n");
+        }
+        return builder.toString();
+    }
+
+    @Override
+    public String toString() {
+        try {
+            return PARSER.stringify(this);
+        } catch (JsonProcessingException e) {
+            throw new RuntimeException(e);
+        }
+    }
+}

--- a/dingo-exec/src/main/java/io/dingodb/exec/fin/OperatorProfile.java
+++ b/dingo-exec/src/main/java/io/dingodb/exec/fin/OperatorProfile.java
@@ -1,0 +1,45 @@
+/*
+ * Copyright 2021 DataCanvas
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package io.dingodb.exec.fin;
+
+import com.fasterxml.jackson.annotation.JsonProperty;
+import io.dingodb.exec.base.Id;
+import lombok.Data;
+
+import java.text.SimpleDateFormat;
+import java.util.Date;
+
+@Data
+public class OperatorProfile {
+    @JsonProperty("id")
+    Id operatorId;
+    @JsonProperty("start")
+    long startTimeStamp;
+    @JsonProperty("end")
+    long endTimeStamp;
+    @JsonProperty("count")
+    long processedTupleCount;
+
+    public String detail() {
+        SimpleDateFormat dateFormat = new SimpleDateFormat("HH:mm:ss.SSS");
+        return "Operator " + operatorId + ":"
+            + " Start: " + dateFormat.format(new Date(startTimeStamp))
+            + " End: " + dateFormat.format(new Date(endTimeStamp))
+            + " Duration: " + (endTimeStamp - startTimeStamp) + "ms"
+            + " Count: " + processedTupleCount;
+    }
+}

--- a/dingo-exec/src/main/java/io/dingodb/exec/impl/JobImpl.java
+++ b/dingo-exec/src/main/java/io/dingodb/exec/impl/JobImpl.java
@@ -52,7 +52,7 @@ public final class JobImpl implements Job {
         this.tasks = new LinkedList<>();
     }
 
-    public static JobImpl deserialize(String str) throws JsonProcessingException {
+    public static JobImpl fromString(String str) throws JsonProcessingException {
         return PARSER.parse(str, JobImpl.class);
     }
 
@@ -71,13 +71,8 @@ public final class JobImpl implements Job {
 
     @Override
     public String toString() {
-        return serialize();
-    }
-
-    @Override
-    public String serialize() {
         try {
-            return PARSER.serialize(this);
+            return PARSER.stringify(this);
         } catch (JsonProcessingException e) {
             throw new RuntimeException(e);
         }

--- a/dingo-exec/src/main/java/io/dingodb/exec/impl/TaskImpl.java
+++ b/dingo-exec/src/main/java/io/dingodb/exec/impl/TaskImpl.java
@@ -33,6 +33,7 @@ import io.dingodb.net.Location;
 import lombok.Getter;
 import lombok.extern.slf4j.Slf4j;
 
+import java.nio.charset.StandardCharsets;
 import java.util.HashMap;
 import java.util.LinkedList;
 import java.util.List;
@@ -113,17 +114,27 @@ public final class TaskImpl implements Task {
             assert operator instanceof SourceOperator
                 : "Operators in run list must be source operator.";
             executorService.execute(() -> {
-                while (operator.push(0, null)) {
-                    log.info("Operator {} need another pushing.", operator.getId());
+                try {
+                    while (operator.push(0, null)) {
+                        log.info("Operator {} need another pushing.", operator.getId());
+                    }
+                } catch (RuntimeException e) {
+                    e.printStackTrace();
                 }
             });
         });
     }
 
+    @Nonnull
     @Override
-    public String serialize() {
+    public byte[] serialize() {
+        return toString().getBytes(StandardCharsets.UTF_8);
+    }
+
+    @Override
+    public String toString() {
         try {
-            return JobImpl.PARSER.serialize(this);
+            return JobImpl.PARSER.stringify(this);
         } catch (JsonProcessingException e) {
             throw new RuntimeException(e);
         }

--- a/dingo-exec/src/main/java/io/dingodb/exec/operator/AbstractOperator.java
+++ b/dingo-exec/src/main/java/io/dingodb/exec/operator/AbstractOperator.java
@@ -19,14 +19,11 @@ package io.dingodb.exec.operator;
 import com.fasterxml.jackson.annotation.JsonInclude;
 import com.fasterxml.jackson.annotation.JsonSubTypes;
 import com.fasterxml.jackson.annotation.JsonTypeInfo;
-import io.dingodb.common.table.TupleSchema;
 import io.dingodb.exec.base.Id;
 import io.dingodb.exec.base.Operator;
 import io.dingodb.exec.base.Task;
 import lombok.Getter;
 import lombok.Setter;
-
-import java.util.Arrays;
 
 @JsonTypeInfo(
     use = JsonTypeInfo.Id.NAME,
@@ -51,17 +48,10 @@ import java.util.Arrays;
 })
 @JsonInclude(JsonInclude.Include.NON_NULL)
 public abstract class AbstractOperator implements Operator {
-    public static Object[] FIN = new Object[0];
-    public static byte[] FIN_BYTES = new byte[0];
-
     @Getter
     @Setter
     protected Id id;
     @Getter
     @Setter
     protected Task task;
-
-    protected static String formatTuple(TupleSchema schema, Object[] tuple) {
-        return Arrays.equals(tuple, FIN) ? "{<<FIN>>}" : schema.formatTuple(tuple);
-    }
 }

--- a/dingo-exec/src/main/java/io/dingodb/exec/operator/CoalesceOperator.java
+++ b/dingo-exec/src/main/java/io/dingodb/exec/operator/CoalesceOperator.java
@@ -20,8 +20,8 @@ import com.fasterxml.jackson.annotation.JsonCreator;
 import com.fasterxml.jackson.annotation.JsonProperty;
 import com.fasterxml.jackson.annotation.JsonPropertyOrder;
 import com.fasterxml.jackson.annotation.JsonTypeName;
+import io.dingodb.exec.fin.Fin;
 
-import java.util.Arrays;
 import javax.annotation.Nonnull;
 
 @JsonTypeName("coalesce")
@@ -36,13 +36,14 @@ public final class CoalesceOperator extends SoleOutMultiInputOperator {
 
     @Override
     public synchronized boolean push(int pin, @Nonnull Object[] tuple) {
-        if (!Arrays.equals(tuple, FIN)) {
-            return pushOutput(tuple);
-        }
-        setFin(pin);
+        return output.push(tuple);
+    }
+
+    @Override
+    public synchronized void fin(int pin, Fin fin) {
+        setFin(pin, fin);
         if (isAllFin()) {
-            return pushOutput(FIN);
+            outputFin();
         }
-        return true;
     }
 }

--- a/dingo-exec/src/main/java/io/dingodb/exec/operator/IteratorSourceOperator.java
+++ b/dingo-exec/src/main/java/io/dingodb/exec/operator/IteratorSourceOperator.java
@@ -16,6 +16,8 @@
 
 package io.dingodb.exec.operator;
 
+import io.dingodb.exec.fin.FinWithProfiles;
+
 import java.util.Iterator;
 
 public abstract class IteratorSourceOperator extends SourceOperator {
@@ -23,13 +25,18 @@ public abstract class IteratorSourceOperator extends SourceOperator {
 
     @Override
     public boolean push() {
+        long count = 0;
+        profile.setStartTimeStamp(System.currentTimeMillis());
         while (iterator.hasNext()) {
             Object[] tuple = iterator.next();
-            if (!pushOutput(tuple)) {
+            ++count;
+            if (!output.push(tuple)) {
                 return false;
             }
         }
-        pushOutput(FIN);
+        profile.setProcessedTupleCount(count);
+        profile.setEndTimeStamp(System.currentTimeMillis());
+        output.pushFin(FinWithProfiles.of(profile));
         return false;
     }
 }

--- a/dingo-exec/src/main/java/io/dingodb/exec/operator/PartDeleteOperator.java
+++ b/dingo-exec/src/main/java/io/dingodb/exec/operator/PartDeleteOperator.java
@@ -23,7 +23,6 @@ import com.fasterxml.jackson.annotation.JsonTypeName;
 import io.dingodb.common.table.TupleMapping;
 import io.dingodb.common.table.TupleSchema;
 
-import java.util.Arrays;
 import javax.annotation.Nonnull;
 
 @JsonTypeName("delete")
@@ -46,13 +45,9 @@ public final class PartDeleteOperator extends PartModifyOperator {
 
     @Override
     public synchronized boolean push(int pin, @Nonnull Object[] tuple) {
-        if (!Arrays.equals(tuple, FIN)) {
-            if (part.remove(tuple)) {
-                count++;
-            }
-            return true;
+        if (part.remove(tuple)) {
+            count++;
         }
-        pushCountAndFin();
-        return false;
+        return true;
     }
 }

--- a/dingo-exec/src/main/java/io/dingodb/exec/operator/PartInsertOperator.java
+++ b/dingo-exec/src/main/java/io/dingodb/exec/operator/PartInsertOperator.java
@@ -23,7 +23,6 @@ import com.fasterxml.jackson.annotation.JsonTypeName;
 import io.dingodb.common.table.TupleMapping;
 import io.dingodb.common.table.TupleSchema;
 
-import java.util.Arrays;
 import javax.annotation.Nonnull;
 
 @JsonTypeName("insert")
@@ -46,13 +45,9 @@ public final class PartInsertOperator extends PartModifyOperator {
 
     @Override
     public synchronized boolean push(int pin, @Nonnull Object[] tuple) {
-        if (!Arrays.equals(tuple, FIN)) {
-            if (part.insert(tuple)) {
-                count++;
-            }
-            return true;
+        if (part.insert(tuple)) {
+            count++;
         }
-        pushCountAndFin();
-        return false;
+        return true;
     }
 }

--- a/dingo-exec/src/main/java/io/dingodb/exec/operator/PartModifyOperator.java
+++ b/dingo-exec/src/main/java/io/dingodb/exec/operator/PartModifyOperator.java
@@ -20,6 +20,7 @@ import com.fasterxml.jackson.annotation.JsonProperty;
 import io.dingodb.common.table.TupleMapping;
 import io.dingodb.common.table.TupleSchema;
 import io.dingodb.exec.Services;
+import io.dingodb.exec.fin.Fin;
 import io.dingodb.exec.table.Part;
 import io.dingodb.exec.table.PartInKvStore;
 import io.dingodb.kvstore.KvStoreInstance;
@@ -61,9 +62,10 @@ public abstract class PartModifyOperator extends SoleOutOperator {
         count = 0;
     }
 
-    protected void pushCountAndFin() {
-        if (pushOutput(new Object[]{count})) {
-            pushOutput(FIN);
+    @Override
+    public void fin(int pin, Fin fin) {
+        if (output.push(new Object[]{count})) {
+            output.pushFin(fin);
         }
     }
 }

--- a/dingo-exec/src/main/java/io/dingodb/exec/operator/PartUpdateOperator.java
+++ b/dingo-exec/src/main/java/io/dingodb/exec/operator/PartUpdateOperator.java
@@ -63,20 +63,16 @@ public final class PartUpdateOperator extends PartModifyOperator {
 
     @Override
     public synchronized boolean push(int pin, @Nonnull Object[] tuple) {
-        if (!Arrays.equals(tuple, FIN)) {
-            TupleEvalContext etx = new TupleEvalContext(Arrays.copyOf(tuple, tuple.length));
-            try {
-                for (int i = 0; i < mapping.size(); ++i) {
-                    tuple[mapping.get(i)] = exprs[i].eval(etx);
-                }
-                part.upsert(tuple);
-                count++;
-            } catch (FailGetEvaluator e) {
-                e.printStackTrace();
+        TupleEvalContext etx = new TupleEvalContext(Arrays.copyOf(tuple, tuple.length));
+        try {
+            for (int i = 0; i < mapping.size(); ++i) {
+                tuple[mapping.get(i)] = exprs[i].eval(etx);
             }
-            return true;
+            part.upsert(tuple);
+            count++;
+        } catch (FailGetEvaluator e) {
+            e.printStackTrace();
         }
-        pushCountAndFin();
-        return false;
+        return true;
     }
 }

--- a/dingo-exec/src/main/java/io/dingodb/exec/operator/PartitionOperator.java
+++ b/dingo-exec/src/main/java/io/dingodb/exec/operator/PartitionOperator.java
@@ -24,6 +24,7 @@ import com.fasterxml.jackson.databind.annotation.JsonDeserialize;
 import com.fasterxml.jackson.databind.annotation.JsonSerialize;
 import io.dingodb.exec.base.Output;
 import io.dingodb.exec.base.OutputHint;
+import io.dingodb.exec.fin.Fin;
 import io.dingodb.exec.impl.OutputIml;
 import io.dingodb.net.Location;
 import lombok.Getter;
@@ -56,6 +57,11 @@ public final class PartitionOperator extends AbstractOperator {
     public synchronized boolean push(int pin, @Nonnull Object[] tuple) {
         // TODO: partition and push next level.
         return false;
+    }
+
+    @Override
+    public void fin(int pin, Fin fin) {
+        // TODO:
     }
 
     public void createOutputs(@Nonnull Map<Object, Location> partLocations) {

--- a/dingo-exec/src/main/java/io/dingodb/exec/operator/ProjectOperator.java
+++ b/dingo-exec/src/main/java/io/dingodb/exec/operator/ProjectOperator.java
@@ -21,12 +21,12 @@ import com.fasterxml.jackson.annotation.JsonProperty;
 import com.fasterxml.jackson.annotation.JsonPropertyOrder;
 import com.fasterxml.jackson.annotation.JsonTypeName;
 import io.dingodb.common.table.TupleSchema;
+import io.dingodb.exec.fin.Fin;
 import io.dingodb.exec.util.ExprUtil;
 import io.dingodb.expr.runtime.RtExpr;
 import io.dingodb.expr.runtime.TupleEvalContext;
 import io.dingodb.expr.runtime.exception.FailGetEvaluator;
 
-import java.util.Arrays;
 import java.util.List;
 import javax.annotation.Nonnull;
 
@@ -52,9 +52,6 @@ public final class ProjectOperator extends SoleOutOperator {
 
     @Nonnull
     public static Object[] doProject(Object[] tuple, @Nonnull RtExpr[] projectExpr) {
-        if (Arrays.equals(tuple, FIN)) {
-            return FIN;
-        }
         Object[] newTuple = new Object[projectExpr.length];
         for (int i = 0; i < newTuple.length; ++i) {
             try {
@@ -75,6 +72,11 @@ public final class ProjectOperator extends SoleOutOperator {
 
     @Override
     public boolean push(int pin, Object[] tuple) {
-        return pushOutput(doProject(tuple, exprs));
+        return output.push(doProject(tuple, exprs));
+    }
+
+    @Override
+    public void fin(int pin, Fin fin) {
+        output.pushFin(fin);
     }
 }

--- a/dingo-exec/src/main/java/io/dingodb/exec/operator/ReduceOperator.java
+++ b/dingo-exec/src/main/java/io/dingodb/exec/operator/ReduceOperator.java
@@ -26,8 +26,8 @@ import io.dingodb.common.table.TupleMapping;
 import io.dingodb.exec.aggregate.AbstractAgg;
 import io.dingodb.exec.aggregate.Agg;
 import io.dingodb.exec.aggregate.AggCache;
+import io.dingodb.exec.fin.Fin;
 
-import java.util.Arrays;
 import java.util.List;
 
 @JsonTypeName("reduce")
@@ -61,20 +61,20 @@ public final class ReduceOperator extends SoleOutMultiInputOperator {
 
     @Override
     public boolean push(int pin, Object[] tuple) {
-        if (Arrays.equals(tuple, FIN)) {
-            setFin(pin);
-            if (isAllFin()) {
-                for (Object[] t : cache) {
-                    if (!pushOutput(t)) {
-                        break;
-                    }
-                }
-                pushOutput(FIN);
-                return false;
-            }
-        } else {
-            cache.reduce(tuple);
-        }
+        cache.reduce(tuple);
         return true;
+    }
+
+    @Override
+    public void fin(int pin, Fin fin) {
+        setFin(pin, fin);
+        if (isAllFin()) {
+            for (Object[] t : cache) {
+                if (!output.push(t)) {
+                    break;
+                }
+            }
+            outputFin();
+        }
     }
 }

--- a/dingo-exec/src/main/java/io/dingodb/exec/operator/RootOperator.java
+++ b/dingo-exec/src/main/java/io/dingodb/exec/operator/RootOperator.java
@@ -21,6 +21,7 @@ import com.fasterxml.jackson.annotation.JsonProperty;
 import com.fasterxml.jackson.annotation.JsonPropertyOrder;
 import com.fasterxml.jackson.annotation.JsonTypeName;
 import io.dingodb.common.table.TupleSchema;
+import io.dingodb.exec.fin.Fin;
 import io.dingodb.exec.util.QueueUtil;
 import lombok.extern.slf4j.Slf4j;
 
@@ -32,6 +33,8 @@ import javax.annotation.Nonnull;
 @JsonTypeName("root")
 @JsonPropertyOrder({"schema"})
 public final class RootOperator extends SinkOperator {
+    public static final Object[] FIN = new Object[0];
+
     @JsonProperty("schema")
     private final TupleSchema schema;
 
@@ -53,10 +56,18 @@ public final class RootOperator extends SinkOperator {
     @Override
     public boolean push(Object[] tuple) {
         if (log.isDebugEnabled()) {
-            log.debug("Put tuple {} into root queue.", formatTuple(schema, tuple));
+            log.debug("Put tuple {} into root queue.", schema.formatTuple(tuple));
         }
         QueueUtil.forcePut(tupleQueue, tuple);
         return true;
+    }
+
+    @Override
+    public void fin(Fin fin) {
+        if (log.isDebugEnabled()) {
+            log.debug("Received FIN. {}", fin.detail());
+        }
+        QueueUtil.forcePut(tupleQueue, FIN);
     }
 
     @Nonnull

--- a/dingo-exec/src/main/java/io/dingodb/exec/operator/SinkOperator.java
+++ b/dingo-exec/src/main/java/io/dingodb/exec/operator/SinkOperator.java
@@ -18,6 +18,7 @@ package io.dingodb.exec.operator;
 
 import com.google.common.collect.ImmutableList;
 import io.dingodb.exec.base.Output;
+import io.dingodb.exec.fin.Fin;
 
 import java.util.List;
 import javax.annotation.Nonnull;
@@ -26,10 +27,18 @@ import javax.annotation.Nonnull;
  * Sink operator has only one input and no output.
  */
 public abstract class SinkOperator extends AbstractOperator {
-    public abstract boolean push(Object[] tuple);
+    protected abstract boolean push(Object[] tuple);
 
+    @Override
     public synchronized boolean push(int pin, @Nonnull Object[] tuple) {
         return push(tuple);
+    }
+
+    protected abstract void fin(Fin fin);
+
+    @Override
+    public void fin(int pin, Fin fin) {
+        fin(fin);
     }
 
     @Override

--- a/dingo-exec/src/main/java/io/dingodb/exec/operator/SoleOutMultiInputOperator.java
+++ b/dingo-exec/src/main/java/io/dingodb/exec/operator/SoleOutMultiInputOperator.java
@@ -17,10 +17,18 @@
 package io.dingodb.exec.operator;
 
 import com.fasterxml.jackson.annotation.JsonProperty;
+import io.dingodb.exec.fin.Fin;
+import io.dingodb.exec.fin.FinWithProfiles;
+import io.dingodb.exec.fin.OperatorProfile;
 import lombok.RequiredArgsConstructor;
+
+import java.util.LinkedList;
+import java.util.List;
 
 @RequiredArgsConstructor
 public abstract class SoleOutMultiInputOperator extends SoleOutOperator {
+    private final List<OperatorProfile> profiles = new LinkedList<>();
+
     @JsonProperty("inputNum")
     private final int inputNum;
     private boolean[] finFlag;
@@ -31,10 +39,13 @@ public abstract class SoleOutMultiInputOperator extends SoleOutOperator {
         finFlag = new boolean[inputNum];
     }
 
-    protected void setFin(int pin) {
+    protected void setFin(int pin, Fin fin) {
         assert pin < inputNum : "Pin no is greater than the max (" + inputNum + ").";
         assert !finFlag[pin] : "Input on pin (" + pin + ") is already finished.";
         finFlag[pin] = true;
+        if (fin instanceof FinWithProfiles) {
+            profiles.addAll(((FinWithProfiles) fin).getProfiles());
+        }
     }
 
     protected boolean isAllFin() {
@@ -44,5 +55,9 @@ public abstract class SoleOutMultiInputOperator extends SoleOutOperator {
             }
         }
         return true;
+    }
+
+    protected void outputFin() {
+        output.pushFin(new FinWithProfiles(profiles));
     }
 }

--- a/dingo-exec/src/main/java/io/dingodb/exec/operator/SoleOutOperator.java
+++ b/dingo-exec/src/main/java/io/dingodb/exec/operator/SoleOutOperator.java
@@ -43,8 +43,4 @@ public abstract class SoleOutOperator extends AbstractOperator {
     public List<Output> getOutputs() {
         return ImmutableList.of(output);
     }
-
-    protected boolean pushOutput(Object[] tuple) {
-        return output.push(tuple);
-    }
 }

--- a/dingo-exec/src/main/java/io/dingodb/exec/operator/SourceOperator.java
+++ b/dingo-exec/src/main/java/io/dingodb/exec/operator/SourceOperator.java
@@ -16,16 +16,31 @@
 
 package io.dingodb.exec.operator;
 
+import io.dingodb.exec.fin.Fin;
+import io.dingodb.exec.fin.OperatorProfile;
+
 import javax.annotation.Nonnull;
 
 /**
  * Source operator has no inputs and only one output.
  */
 public abstract class SourceOperator extends SoleOutOperator {
+    protected final OperatorProfile profile = new OperatorProfile();
+
+    @Override
+    public void init() {
+        super.init();
+        profile.setOperatorId(id);
+    }
+
     public abstract boolean push();
 
     @Override
     public synchronized boolean push(int pin, @Nonnull Object[] tuple) {
         return push();
+    }
+
+    @Override
+    public synchronized void fin(int pin, Fin fin) {
     }
 }

--- a/dingo-exec/src/main/java/io/dingodb/exec/operator/SumUpOperator.java
+++ b/dingo-exec/src/main/java/io/dingodb/exec/operator/SumUpOperator.java
@@ -20,8 +20,8 @@ import com.fasterxml.jackson.annotation.JsonCreator;
 import com.fasterxml.jackson.annotation.JsonProperty;
 import com.fasterxml.jackson.annotation.JsonPropertyOrder;
 import com.fasterxml.jackson.annotation.JsonTypeName;
+import io.dingodb.exec.fin.Fin;
 
-import java.util.Arrays;
 import javax.annotation.Nonnull;
 
 @JsonTypeName("sumUp")
@@ -45,17 +45,17 @@ public class SumUpOperator extends SoleOutMultiInputOperator {
 
     @Override
     public synchronized boolean push(int pin, @Nonnull Object[] tuple) {
-        if (!Arrays.equals(tuple, FIN)) {
-            sum += (long) tuple[0];
-            return true;
-        }
-        setFin(pin);
-        if (isAllFin()) {
-            if (pushOutput(new Object[]{sum})) {
-                pushOutput(FIN);
-            }
-            return false;
-        }
+        sum += (long) tuple[0];
         return true;
+    }
+
+    @Override
+    public void fin(int pin, Fin fin) {
+        setFin(pin, fin);
+        if (isAllFin()) {
+            if (output.push(new Object[]{sum})) {
+                outputFin();
+            }
+        }
     }
 }

--- a/dingo-expr/json-runtime/build.gradle
+++ b/dingo-expr/json-runtime/build.gradle
@@ -26,4 +26,5 @@ dependencies {
     implementation group: 'com.fasterxml.jackson.core', name: 'jackson-databind', version: 'jackson'.v()
     implementation group: 'com.fasterxml.jackson.dataformat', name: 'jackson-dataformat-csv', version: 'jackson'.v()
     implementation group: 'com.fasterxml.jackson.dataformat', name: 'jackson-dataformat-yaml', version: 'jackson'.v()
+    implementation group: 'com.fasterxml.jackson.module', name: 'jackson-module-afterburner', version: 'jackson'.v()
 }

--- a/dingo-expr/json-runtime/src/main/java/io/dingodb/expr/json/runtime/Parser.java
+++ b/dingo-expr/json-runtime/src/main/java/io/dingodb/expr/json/runtime/Parser.java
@@ -25,6 +25,7 @@ import com.fasterxml.jackson.dataformat.csv.CsvMapper;
 import com.fasterxml.jackson.dataformat.csv.CsvParser;
 import com.fasterxml.jackson.dataformat.yaml.YAMLFactory;
 import com.fasterxml.jackson.dataformat.yaml.YAMLGenerator;
+import com.fasterxml.jackson.module.afterburner.AfterburnerModule;
 
 import java.io.IOException;
 import java.io.InputStream;
@@ -44,12 +45,18 @@ public class Parser implements Serializable {
     protected Parser(@Nonnull DataFormat format) {
         switch (format) {
             case APPLICATION_JSON:
-                mapper = setJsonFeature(new JsonMapper());
+                mapper = JsonMapper.builder()
+                    .addModule(new AfterburnerModule())
+                    .build();
+                setJsonFeature(mapper);
                 break;
             case APPLICATION_YAML:
                 YAMLFactory yamlFactory = new YAMLFactory()
                     .enable(YAMLGenerator.Feature.MINIMIZE_QUOTES);
-                mapper = setJsonFeature(new ObjectMapper(yamlFactory));
+                mapper = JsonMapper.builder(yamlFactory)
+                    .addModule(new AfterburnerModule())
+                    .build();
+                setJsonFeature(mapper);
                 break;
             case TEXT_CSV:
                 mapper = setCsvFeature(new CsvMapper());
@@ -60,8 +67,7 @@ public class Parser implements Serializable {
         }
     }
 
-    @Nonnull
-    private static ObjectMapper setJsonFeature(@Nonnull ObjectMapper mapper) {
+    private static void setJsonFeature(@Nonnull ObjectMapper mapper) {
         mapper.disable(MapperFeature.AUTO_DETECT_FIELDS);
         mapper.disable(MapperFeature.AUTO_DETECT_GETTERS);
         mapper.disable(MapperFeature.AUTO_DETECT_IS_GETTERS);
@@ -69,7 +75,6 @@ public class Parser implements Serializable {
         mapper.disable(MapperFeature.AUTO_DETECT_CREATORS);
         mapper.enable(SerializationFeature.ORDER_MAP_ENTRIES_BY_KEYS);
         mapper.enable(SerializationFeature.INDENT_OUTPUT);
-        return mapper;
     }
 
     @Nonnull
@@ -102,7 +107,7 @@ public class Parser implements Serializable {
         return mapper.readValue(is, clazz);
     }
 
-    public <T> String serialize(T obj) throws JsonProcessingException {
+    public <T> String stringify(T obj) throws JsonProcessingException {
         return mapper.writeValueAsString(obj);
     }
 

--- a/dingo-expr/json-schema/src/main/java/io/dingodb/expr/json/schema/SchemaParser.java
+++ b/dingo-expr/json-schema/src/main/java/io/dingodb/expr/json/schema/SchemaParser.java
@@ -80,6 +80,6 @@ public final class SchemaParser extends Parser {
      * @throws JsonProcessingException if something is wrong
      */
     public String serialize(@Nonnull RtSchemaRoot rtSchemaRoot) throws JsonProcessingException {
-        return serialize(rtSchemaRoot.getSchema());
+        return stringify(rtSchemaRoot.getSchema());
     }
 }

--- a/dingo-server/src/main/java/io/dingodb/server/SqlExecutor.java
+++ b/dingo-server/src/main/java/io/dingodb/server/SqlExecutor.java
@@ -114,7 +114,7 @@ public class SqlExecutor implements MessageListener {
     }
 
     private String serializeResult(Object result) throws JsonProcessingException {
-        return JSON.serialize(result);
+        return JSON.stringify(result);
     }
 
     public static class SqlExecutorProvider implements MessageListenerProvider {

--- a/dingo-test/src/test/java/io/dingodb/test/CustomTestOrder.java
+++ b/dingo-test/src/test/java/io/dingodb/test/CustomTestOrder.java
@@ -31,6 +31,7 @@ public class CustomTestOrder implements MethodOrderer {
         "testExplainInsertValues",
         "testExplainScan",
         "testSimpleValues",
+        "testInsert",
         "testScan",
         "testScan2",
         "testGetByKey",

--- a/dingo-test/src/test/java/io/dingodb/test/QueryTest.java
+++ b/dingo-test/src/test/java/io/dingodb/test/QueryTest.java
@@ -27,6 +27,7 @@ import org.junit.jupiter.api.BeforeAll;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.TestMethodOrder;
 
+import java.io.IOException;
 import java.net.DatagramSocket;
 import java.sql.Connection;
 import java.sql.ResultSet;
@@ -51,8 +52,6 @@ public class QueryTest {
         SqlHelper.execUpdate("/table-test-create.sql");
         SqlHelper.execUpdate("/table-test1-create.sql");
         SqlHelper.execUpdate("/table-test2-create.sql");
-        SqlHelper.execUpdate("/table-test-data.sql");
-        SqlHelper.execUpdate("/table-test2-data.sql");
         connection = Connections.getConnection();
     }
 
@@ -61,6 +60,7 @@ public class QueryTest {
         connection.close();
         Services.META.clear();
     }
+
 
     private static void checkDatumInTestTable(String data) throws SQLException {
         String sql = "select * from test";
@@ -132,6 +132,12 @@ public class QueryTest {
                 );
             }
         }
+    }
+
+    @Test
+    public void testInsert() throws SQLException, IOException {
+        SqlHelper.execUpdate("/table-test-data.sql");
+        SqlHelper.execUpdate("/table-test2-data.sql");
     }
 
     @Test


### PR DESCRIPTION
Collected starting timestamp, stopping timestamp, processed tuple count. Only source operators such as PartScanOperator, ReceiveOperator are collected, because other operators are bound to these source operators and run in the same thread.

All tests run and passed.