### PR TITLE
[dingo-exec] Fixed #52: Support MIN, MAX aggregation enhancement

### DIFF
--- a/dingo-calcite/src/main/java/io/dingodb/calcite/rule/AggFactory.java
+++ b/dingo-calcite/src/main/java/io/dingodb/calcite/rule/AggFactory.java
@@ -1,0 +1,57 @@
+/*
+ * Copyright 2021 DataCanvas
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package io.dingodb.calcite.rule;
+
+import io.dingodb.common.table.TupleSchema;
+import io.dingodb.exec.aggregate.Agg;
+import io.dingodb.exec.aggregate.CountAgg;
+import io.dingodb.exec.aggregate.MaxAgg;
+import io.dingodb.exec.aggregate.MinAgg;
+import io.dingodb.exec.aggregate.SumAgg;
+import org.apache.calcite.sql.SqlKind;
+
+import java.util.List;
+import javax.annotation.Nonnull;
+
+import static io.dingodb.common.util.Utils.sole;
+
+final class AggFactory {
+    private AggFactory() {
+    }
+
+    @Nonnull
+    static Agg getAgg(@Nonnull SqlKind kind, List<Integer> args, TupleSchema schema) {
+        int index;
+        switch (kind) {
+            case COUNT:
+                return new CountAgg();
+            case SUM:
+            case SUM0:
+                index = sole(args);
+                return new SumAgg(index, schema.get(index));
+            case MIN:
+                index = sole(args);
+                return new MinAgg(index, schema.get(index));
+            case MAX:
+                index = sole(args);
+                return new MaxAgg(index, schema.get(index));
+            default:
+                break;
+        }
+        throw new UnsupportedOperationException("Unsupported aggregation function \"" + kind + "\".");
+    }
+}

--- a/dingo-exec/src/main/java/io/dingodb/exec/aggregate/AbstractAgg.java
+++ b/dingo-exec/src/main/java/io/dingodb/exec/aggregate/AbstractAgg.java
@@ -26,6 +26,8 @@ import com.fasterxml.jackson.annotation.JsonTypeInfo;
 @JsonSubTypes({
     @JsonSubTypes.Type(CountAgg.class),
     @JsonSubTypes.Type(SumAgg.class),
+    @JsonSubTypes.Type(MinAgg.class),
+    @JsonSubTypes.Type(MaxAgg.class),
 })
 public abstract class AbstractAgg implements Agg {
 }

--- a/dingo-exec/src/main/java/io/dingodb/exec/aggregate/Agg.java
+++ b/dingo-exec/src/main/java/io/dingodb/exec/aggregate/Agg.java
@@ -17,11 +17,30 @@
 package io.dingodb.exec.aggregate;
 
 public interface Agg {
-    Object init();
+    /**
+     * Called when the first tuple arrived.
+     *
+     * @param tuple the tuple
+     * @return the aggregating context, may be a compound type
+     */
+    Object first(Object[] tuple);
 
     Object add(Object var, Object[] tuple);
 
+    /**
+     * Called to merge two aggregating context.
+     *
+     * @param var1 the 1st aggregating context, may be null
+     * @param var2 the 2nd aggregating context, may be null
+     * @return the merged aggregating context
+     */
     Object merge(Object var1, Object var2);
 
+    /**
+     * Called to get the output value from aggregating context.
+     *
+     * @param var the aggregating context, may be null
+     * @return the output value
+     */
     Object getValue(Object var);
 }

--- a/dingo-exec/src/main/java/io/dingodb/exec/aggregate/CountAgg.java
+++ b/dingo-exec/src/main/java/io/dingodb/exec/aggregate/CountAgg.java
@@ -21,8 +21,8 @@ import com.fasterxml.jackson.annotation.JsonTypeName;
 @JsonTypeName("count")
 public class CountAgg extends AbstractAgg {
     @Override
-    public Object init() {
-        return 0L;
+    public Object first(Object[] tuple) {
+        return 1L;
     }
 
     @Override
@@ -32,11 +32,17 @@ public class CountAgg extends AbstractAgg {
 
     @Override
     public Object merge(Object var1, Object var2) {
-        return (long) var1 + (long) var2;
+        if (var1 != null) {
+            if (var2 != null) {
+                return (long) var1 + (long) var2;
+            }
+            return var1;
+        }
+        return var2;
     }
 
     @Override
     public Object getValue(Object var) {
-        return var;
+        return var != null ? var : 0L;
     }
 }

--- a/dingo-exec/src/main/java/io/dingodb/exec/aggregate/MaxAgg.java
+++ b/dingo-exec/src/main/java/io/dingodb/exec/aggregate/MaxAgg.java
@@ -20,18 +20,18 @@ import com.fasterxml.jackson.annotation.JsonCreator;
 import com.fasterxml.jackson.annotation.JsonProperty;
 import com.fasterxml.jackson.annotation.JsonTypeName;
 import io.dingodb.common.table.ElementSchema;
-import io.dingodb.expr.runtime.evaluator.arithmetic.AddEvaluatorFactory;
+import io.dingodb.expr.runtime.evaluator.arithmetic.MaxEvaluatorFactory;
 
 import javax.annotation.Nonnull;
 
-@JsonTypeName("sum")
-public class SumAgg extends UnityEvaluatorAgg {
+@JsonTypeName("max")
+public class MaxAgg extends UnityEvaluatorAgg {
     @JsonCreator
-    public SumAgg(
+    public MaxAgg(
         @JsonProperty("index") int index,
         @Nonnull @JsonProperty("type") ElementSchema type
     ) {
         super(index, type);
-        setEvaluator(AddEvaluatorFactory.INSTANCE);
+        setEvaluator(MaxEvaluatorFactory.INSTANCE);
     }
 }

--- a/dingo-exec/src/main/java/io/dingodb/exec/aggregate/MinAgg.java
+++ b/dingo-exec/src/main/java/io/dingodb/exec/aggregate/MinAgg.java
@@ -20,18 +20,18 @@ import com.fasterxml.jackson.annotation.JsonCreator;
 import com.fasterxml.jackson.annotation.JsonProperty;
 import com.fasterxml.jackson.annotation.JsonTypeName;
 import io.dingodb.common.table.ElementSchema;
-import io.dingodb.expr.runtime.evaluator.arithmetic.AddEvaluatorFactory;
+import io.dingodb.expr.runtime.evaluator.arithmetic.MinEvaluatorFactory;
 
 import javax.annotation.Nonnull;
 
-@JsonTypeName("sum")
-public class SumAgg extends UnityEvaluatorAgg {
+@JsonTypeName("min")
+public class MinAgg extends UnityEvaluatorAgg {
     @JsonCreator
-    public SumAgg(
+    public MinAgg(
         @JsonProperty("index") int index,
         @Nonnull @JsonProperty("type") ElementSchema type
     ) {
         super(index, type);
-        setEvaluator(AddEvaluatorFactory.INSTANCE);
+        setEvaluator(MinEvaluatorFactory.INSTANCE);
     }
 }

--- a/dingo-exec/src/main/java/io/dingodb/exec/aggregate/UnityEvaluatorAgg.java
+++ b/dingo-exec/src/main/java/io/dingodb/exec/aggregate/UnityEvaluatorAgg.java
@@ -1,0 +1,87 @@
+/*
+ * Copyright 2021 DataCanvas
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package io.dingodb.exec.aggregate;
+
+import com.fasterxml.jackson.annotation.JsonProperty;
+import io.dingodb.common.table.ElementSchema;
+import io.dingodb.expr.runtime.evaluator.base.Evaluator;
+import io.dingodb.expr.runtime.evaluator.base.EvaluatorFactory;
+import io.dingodb.expr.runtime.evaluator.base.EvaluatorKey;
+import io.dingodb.expr.runtime.exception.FailGetEvaluator;
+
+import javax.annotation.Nonnull;
+
+public abstract class UnityEvaluatorAgg extends AbstractAgg {
+    @JsonProperty("index")
+    protected final int index;
+    @JsonProperty("type")
+    protected final ElementSchema type;
+
+    private Evaluator evaluator;
+
+    protected UnityEvaluatorAgg(int index, ElementSchema type) {
+        this.index = index;
+        this.type = type;
+    }
+
+    protected void setEvaluator(@Nonnull EvaluatorFactory factory) {
+        EvaluatorKey evaluatorKey = EvaluatorKey.of(type.getTypeCode(), type.getTypeCode());
+        try {
+            evaluator = factory.getEvaluator(evaluatorKey);
+        } catch (FailGetEvaluator e) {
+            throw new RuntimeException(e);
+        }
+    }
+
+    protected Object eval(Object v0, Object v1) {
+        try {
+            return evaluator.eval(new Object[]{v0, v1});
+        } catch (FailGetEvaluator e) {
+            throw new RuntimeException(e);
+        }
+    }
+
+    @Override
+    public Object first(@Nonnull Object[] tuple) {
+        return tuple[index];
+    }
+
+    @Override
+    public Object add(Object var, @Nonnull Object[] tuple) {
+        Object value = tuple[index];
+        if (var == null) {
+            return value;
+        }
+        return eval(var, value);
+    }
+
+    @Override
+    public Object merge(Object var1, Object var2) {
+        if (var1 != null) {
+            if (var2 != null) {
+                return eval(var1, var2);
+            }
+            return var1;
+        }
+        return var2;
+    }
+
+    @Override
+    public Object getValue(Object var) {
+        return var;
+    }
+}

--- a/dingo-expr/parser/src/main/java/io/dingodb/expr/parser/op/FunFactory.java
+++ b/dingo-expr/parser/src/main/java/io/dingodb/expr/parser/op/FunFactory.java
@@ -18,6 +18,8 @@ package io.dingodb.expr.parser.op;
 
 import io.dingodb.expr.runtime.RtExpr;
 import io.dingodb.expr.runtime.evaluator.arithmetic.AbsEvaluatorFactory;
+import io.dingodb.expr.runtime.evaluator.arithmetic.MaxEvaluatorFactory;
+import io.dingodb.expr.runtime.evaluator.arithmetic.MinEvaluatorFactory;
 import io.dingodb.expr.runtime.evaluator.base.EvaluatorFactory;
 import io.dingodb.expr.runtime.evaluator.mathematical.AcosEvaluatorFactory;
 import io.dingodb.expr.runtime.evaluator.mathematical.AsinEvaluatorFactory;
@@ -57,6 +59,9 @@ public final class FunFactory {
 
     private FunFactory() {
         funSuppliers = new HashMap<>(64);
+        // min, max
+        registerEvaluator("min", MinEvaluatorFactory.INSTANCE);
+        registerEvaluator("max", MaxEvaluatorFactory.INSTANCE);
         // Mathematical
         registerEvaluator("abs", AbsEvaluatorFactory.INSTANCE);
         registerEvaluator("sin", SinEvaluatorFactory.INSTANCE);

--- a/dingo-expr/parser/src/test/java/io/dingodb/expr/parser/parser/TestWithoutVar.java
+++ b/dingo-expr/parser/src/test/java/io/dingodb/expr/parser/parser/TestWithoutVar.java
@@ -175,7 +175,14 @@ public class TestWithoutVar {
             arguments("decimal(8.5)", BigDecimal.valueOf(8.5)),
             arguments("decimal(decimal(8.5))", BigDecimal.valueOf(8.5)),
             arguments("decimal('8.5')", new BigDecimal("8.5")),
-            arguments("substring(string(TAU), 0, 4)", "6.28")
+            arguments("substring(string(TAU), 0, 4)", "6.28"),
+            // min, max
+            arguments("min(3, 5)", 3L),
+            arguments("min(7.5, 5)", 5.0),
+            arguments("min(decimal(3), 5.0)", BigDecimal.valueOf(3)),
+            arguments("max(3, 5)", 5L),
+            arguments("max(7.5, 5)", 7.5),
+            arguments("max(decimal(3), 5.0)", BigDecimal.valueOf(5.0))
         );
     }
 

--- a/dingo-expr/runtime/src/main/java/io/dingodb/expr/runtime/evaluator/arithmetic/ArithmeticEvaluators.java
+++ b/dingo-expr/runtime/src/main/java/io/dingodb/expr/runtime/evaluator/arithmetic/ArithmeticEvaluators.java
@@ -194,4 +194,44 @@ final class ArithmeticEvaluators {
     static double abs(double num) {
         return Math.abs(num);
     }
+
+    @Evaluators.Base(IntegerEvaluator.class)
+    static int min(int value0, int value1) {
+        return Math.min(value0, value1);
+    }
+
+    @Evaluators.Base(LongEvaluator.class)
+    static long min(long value0, long value1) {
+        return Math.min(value0, value1);
+    }
+
+    @Evaluators.Base(DoubleEvaluator.class)
+    static double min(double value0, double value1) {
+        return Math.min(value0, value1);
+    }
+
+    @Evaluators.Base(DecimalEvaluator.class)
+    static BigDecimal min(@Nonnull BigDecimal value0, BigDecimal value1) {
+        return value0.compareTo(value1) <= 0 ? value0 : value1;
+    }
+
+    @Evaluators.Base(IntegerEvaluator.class)
+    static int max(int value0, int value1) {
+        return Math.max(value0, value1);
+    }
+
+    @Evaluators.Base(LongEvaluator.class)
+    static long max(long value0, long value1) {
+        return Math.max(value0, value1);
+    }
+
+    @Evaluators.Base(DoubleEvaluator.class)
+    static double max(double value0, double value1) {
+        return Math.max(value0, value1);
+    }
+
+    @Evaluators.Base(DecimalEvaluator.class)
+    static BigDecimal max(@Nonnull BigDecimal value0, BigDecimal value1) {
+        return value0.compareTo(value1) >= 0 ? value0 : value1;
+    }
 }

--- a/dingo-test/src/test/java/io/dingodb/test/QueryTest.java
+++ b/dingo-test/src/test/java/io/dingodb/test/QueryTest.java
@@ -19,8 +19,6 @@ package io.dingodb.test;
 import io.dingodb.calcite.Connections;
 import io.dingodb.common.table.TupleSchema;
 import io.dingodb.exec.Services;
-import io.dingodb.meta.test.MetaTestService;
-import io.dingodb.net.netty.NetServiceConfiguration;
 import io.dingodb.test.asserts.AssertResultSet;
 import lombok.extern.slf4j.Slf4j;
 import org.junit.jupiter.api.AfterAll;
@@ -31,7 +29,6 @@ import org.junit.jupiter.api.Disabled;
 import org.junit.jupiter.api.Test;
 
 import java.io.IOException;
-import java.net.DatagramSocket;
 import java.sql.Connection;
 import java.sql.ResultSet;
 import java.sql.SQLException;
@@ -355,6 +352,34 @@ public class QueryTest {
                     new String[]{"all_sum"},
                     TupleSchema.ofTypes("DOUBLE"),
                     "49.5\n"
+                );
+            }
+        }
+    }
+
+    @Test
+    public void testMin() throws SQLException {
+        String sql = "select min(amount) as min_amount from test";
+        try (Statement statement = connection.createStatement()) {
+            try (ResultSet resultSet = statement.executeQuery(sql)) {
+                AssertResultSet.of(resultSet).isRecords(
+                    new String[]{"min_amount"},
+                    TupleSchema.ofTypes("DOUBLE"),
+                    "3.5\n"
+                );
+            }
+        }
+    }
+
+    @Test
+    public void testMax() throws SQLException {
+        String sql = "select max(amount) as max_amount from test";
+        try (Statement statement = connection.createStatement()) {
+            try (ResultSet resultSet = statement.executeQuery(sql)) {
+                AssertResultSet.of(resultSet).isRecords(
+                    new String[]{"max_amount"},
+                    TupleSchema.ofTypes("DOUBLE"),
+                    "7.5\n"
                 );
             }
         }


### PR DESCRIPTION
MIN, MAX is similar to SUM that they are bound to one column, so they can share some common code.