### PR TITLE
[dingo-calcite] Fixed #43: Support multiple schema

### DIFF
--- a/dingo-calcite/src/main/java/io/dingodb/calcite/Connections.java
+++ b/dingo-calcite/src/main/java/io/dingodb/calcite/Connections.java
@@ -39,12 +39,18 @@ public final class Connections {
     }
 
     public static Connection getConnection() throws SQLException {
+        return getConnection(DingoRootSchema.DEFAULT_SCHEMA_NAME);
+    }
+
+    public static Connection getConnection(String defaultSchema) throws SQLException {
         try {
             Class.forName("io.dingodb.driver.DingoDriver");
         } catch (ClassNotFoundException e) {
             throw new RuntimeException(e);
         }
-        return DriverManager.getConnection("jdbc:dingo:");
+        Properties properties = new Properties();
+        properties.setProperty("defaultSchema", defaultSchema);
+        return DriverManager.getConnection("jdbc:dingo:", properties);
     }
 
     @SuppressWarnings("unused")
@@ -60,10 +66,11 @@ public final class Connections {
         Properties props = new Properties();
         String sb = "inline: {\n"
             + "  version: '1.0',\n"
-            + "  defaultSchema: '" + DingoSchema.SCHEMA_NAME + "',\n"
+            + "  defaultSchema: '" + DingoRootSchema.ROOT_SCHEMA_NAME
+            + "." + DingoRootSchema.DEFAULT_SCHEMA_NAME + "',\n"
             + "  schemas: [ {\n"
             + "    type: 'custom',\n"
-            + "    name: '" + DingoSchema.SCHEMA_NAME + "',\n"
+            + "    name: '" + DingoRootSchema.ROOT_SCHEMA_NAME + "',\n"
             + "    factory: '" + DingoSchemaFactory.class.getCanonicalName() + "',\n"
             + "    operand: {\n"
             + "    }\n"

--- a/dingo-calcite/src/main/java/io/dingodb/calcite/DingoParser.java
+++ b/dingo-calcite/src/main/java/io/dingodb/calcite/DingoParser.java
@@ -20,7 +20,6 @@ import com.google.common.collect.ImmutableList;
 import io.dingodb.calcite.rule.DingoRules;
 import lombok.Getter;
 import org.apache.calcite.adapter.enumerable.EnumerableConvention;
-import org.apache.calcite.config.CalciteConnectionConfig;
 import org.apache.calcite.config.CalciteConnectionConfigImpl;
 import org.apache.calcite.config.CalciteConnectionProperty;
 import org.apache.calcite.plan.Convention;
@@ -84,7 +83,7 @@ public class DingoParser {
 
         catalogReader = new CalciteCatalogReader(
             context.getRootSchema(),
-            Collections.singletonList(DingoSchema.SCHEMA_NAME),
+            Collections.singletonList(context.getDefaultSchemaName()),
             context.getTypeFactory(),
             new CalciteConnectionConfigImpl(properties)
         );

--- a/dingo-calcite/src/main/java/io/dingodb/calcite/DingoParserContext.java
+++ b/dingo-calcite/src/main/java/io/dingodb/calcite/DingoParserContext.java
@@ -23,26 +23,34 @@ import org.apache.calcite.jdbc.CalciteSchema;
 import org.apache.calcite.jdbc.JavaTypeFactoryImpl;
 import org.apache.calcite.schema.impl.ScalarFunctionImpl;
 
-
 // These are static for every sql parsing.
 public final class DingoParserContext {
     @Getter
     private final JavaTypeFactory typeFactory;
     @Getter
     private final CalciteSchema rootSchema;
-
+    @Getter
+    private final String defaultSchemaName;
 
     public DingoParserContext() {
+        this(DingoRootSchema.DEFAULT_SCHEMA_NAME);
+    }
+
+    public DingoParserContext(String defaultSchemaName) {
+        this.defaultSchemaName = defaultSchemaName;
         typeFactory = new JavaTypeFactoryImpl();
         rootSchema = CalciteSchema.createRootSchema(
             true,
             false,
-            DingoSchema.SCHEMA_NAME,
-            DingoSchema.ROOT
+            DingoRootSchema.ROOT_SCHEMA_NAME,
+            DingoRootSchema.ROOT
         );
-
         DingoFunc.DINGO_FUNC_LIST.build().forEach((k, v) -> {
             rootSchema.plus().add(k, ScalarFunctionImpl.create(DingoFunc.class, v));
         });
+    }
+
+    public CalciteSchema getDefaultSchema() {
+        return rootSchema.getSubSchema(defaultSchemaName, true);
     }
 }

--- a/dingo-calcite/src/main/java/io/dingodb/calcite/DingoRootSchema.java
+++ b/dingo-calcite/src/main/java/io/dingodb/calcite/DingoRootSchema.java
@@ -16,33 +16,28 @@
 
 package io.dingodb.calcite;
 
-import io.dingodb.common.table.TableDefinition;
-import io.dingodb.ddl.MutableSchema;
+import io.dingodb.exec.Services;
 import io.dingodb.meta.MetaService;
 import org.apache.calcite.schema.Schema;
-import org.apache.calcite.schema.Table;
+import org.apache.calcite.schema.impl.AbstractSchema;
 
-import java.util.LinkedHashMap;
+import java.util.HashMap;
 import java.util.Map;
 
-public class DingoSchema extends MutableSchema {
-    DingoSchema(MetaService metaService) {
-        super(metaService);
+public class DingoRootSchema extends AbstractSchema {
+    public static final String ROOT_SCHEMA_NAME = "DINGO_ROOT";
+    public static final String DEFAULT_SCHEMA_NAME = "DINGO";
+    public static final DingoRootSchema ROOT = new DingoRootSchema();
+
+    private DingoRootSchema() {
     }
 
     @Override
     protected Map<String, Schema> getSubSchemaMap() {
-        return super.getSubSchemaMap();
-    }
-
-    @Override
-    protected Map<String, Table> getTableMap() {
-        Map<String, TableDefinition> tds = metaService.getTableDefinitions();
-        if (tds == null) {
-            return super.getTableMap(); // empty map
+        Map<String, Schema> schemaMap = new HashMap<>(Services.metaServices.size());
+        for (MetaService metaService : Services.metaServices.values()) {
+            schemaMap.put(metaService.getName(), new DingoSchema(metaService));
         }
-        Map<String, Table> tableMap = new LinkedHashMap<>();
-        tds.forEach((name, td) -> tableMap.put(name, new DingoTable(td)));
-        return tableMap;
+        return schemaMap;
     }
 }

--- a/dingo-calcite/src/main/java/io/dingodb/calcite/DingoSchemaFactory.java
+++ b/dingo-calcite/src/main/java/io/dingodb/calcite/DingoSchemaFactory.java
@@ -29,6 +29,6 @@ public class DingoSchemaFactory implements SchemaFactory {
     @Override
     public Schema create(SchemaPlus schemaPlus, String name, Map<String, Object> operand) {
         log.info("schemaPlus = {}, name = {}, operand = {}", schemaPlus, name, operand);
-        return DingoSchema.ROOT;
+        return DingoRootSchema.ROOT;
     }
 }

--- a/dingo-calcite/src/main/java/io/dingodb/calcite/rel/EnumerableRoot.java
+++ b/dingo-calcite/src/main/java/io/dingodb/calcite/rel/EnumerableRoot.java
@@ -16,9 +16,12 @@
 
 package io.dingodb.calcite.rel;
 
+import io.dingodb.calcite.DingoRootSchema;
 import io.dingodb.calcite.JobRunner;
 import io.dingodb.calcite.visitor.DingoJobVisitor;
+import io.dingodb.exec.Services;
 import io.dingodb.exec.base.Job;
+import io.dingodb.meta.Location;
 import org.apache.calcite.adapter.enumerable.EnumerableRel;
 import org.apache.calcite.adapter.enumerable.EnumerableRelImplementor;
 import org.apache.calcite.adapter.enumerable.PhysType;
@@ -55,8 +58,9 @@ public final class EnumerableRoot extends SingleRel implements EnumerableRel {
             pref.preferArray()
         );
         RelNode input = getInput();
-        assert input instanceof DingoRel : "The input must be DINGO.";
-        Job job = DingoJobVisitor.createJob(input, true);
+        assert input instanceof DingoRel : "The input must be DINGO_ROOT.";
+        Location currentLocation = Services.metaServices.get(DingoRootSchema.DEFAULT_SCHEMA_NAME).currentLocation();
+        Job job = DingoJobVisitor.createJob(input, currentLocation, true);
         // The result set would be treated as `Object` instead of `Object[]` if the result has only one column.
         String methodName = getRowType().getFieldCount() == 1 ? "runOneColumn" : "run";
         try {

--- a/dingo-calcite/src/main/java/io/dingodb/calcite/visitor/MetaHelper.java
+++ b/dingo-calcite/src/main/java/io/dingodb/calcite/visitor/MetaHelper.java
@@ -1,0 +1,56 @@
+/*
+ * Copyright 2021 DataCanvas
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package io.dingodb.calcite.visitor;
+
+import io.dingodb.common.table.TableDefinition;
+import io.dingodb.common.table.TableId;
+import io.dingodb.exec.Services;
+import io.dingodb.meta.Location;
+import io.dingodb.meta.MetaService;
+import lombok.Getter;
+import org.apache.calcite.plan.RelOptTable;
+
+import java.util.List;
+import java.util.Map;
+import java.util.stream.Collectors;
+import javax.annotation.Nonnull;
+
+class MetaHelper {
+    @Getter
+    private final MetaService metaService;
+    @Getter
+    private final String tableName;
+
+    MetaHelper(@Nonnull RelOptTable table) {
+        List<String> fullName = table.getQualifiedName();
+        // `fullName.get(0)` is the root schema.
+        metaService = Services.metaServices.get(fullName.get(1));
+        tableName = fullName.stream().skip(2).collect(Collectors.joining("."));
+    }
+
+    TableDefinition getTableDefinition() {
+        return metaService.getTableDefinition(tableName);
+    }
+
+    Map<String, Location> getPartLocations() {
+        return metaService.getPartLocations(tableName);
+    }
+
+    TableId getTableId() {
+        return new TableId(metaService.getTableKey(tableName));
+    }
+}

--- a/dingo-calcite/src/test/java/io/dingodb/calcite/TestDingoParser.java
+++ b/dingo-calcite/src/test/java/io/dingodb/calcite/TestDingoParser.java
@@ -17,6 +17,7 @@
 package io.dingodb.calcite;
 
 import com.google.common.collect.ImmutableList;
+import io.dingodb.calcite.mock.MockMetaServiceProvider;
 import org.apache.calcite.rel.type.RelDataType;
 import org.apache.calcite.rel.type.RelDataTypeFactory;
 import org.apache.calcite.rel.type.RelDataTypeSystem;
@@ -36,7 +37,7 @@ public class TestDingoParser {
 
     @BeforeAll
     public static void setupAll() {
-        DingoParserContext context = new DingoParserContext();
+        DingoParserContext context = new DingoParserContext(MockMetaServiceProvider.SCHEMA_NAME);
         parser = new DingoParser(context);
     }
 
@@ -71,9 +72,9 @@ public class TestDingoParser {
         SqlNode sqlNode = parse("select id, name, amount from test");
         List<List<String>> fieldOrigins = parser.getFieldOrigins(sqlNode);
         assertThat(fieldOrigins).isEqualTo(ImmutableList.of(
-            ImmutableList.of("DINGO", "TEST", "ID"),
-            ImmutableList.of("DINGO", "TEST", "NAME"),
-            ImmutableList.of("DINGO", "TEST", "AMOUNT")
+            ImmutableList.of("DINGO_ROOT", "MOCK", "TEST", "ID"),
+            ImmutableList.of("DINGO_ROOT", "MOCK", "TEST", "NAME"),
+            ImmutableList.of("DINGO_ROOT", "MOCK", "TEST", "AMOUNT")
         ));
     }
 }

--- a/dingo-calcite/src/test/java/io/dingodb/calcite/TestLogicalPlan.java
+++ b/dingo-calcite/src/test/java/io/dingodb/calcite/TestLogicalPlan.java
@@ -18,6 +18,7 @@ package io.dingodb.calcite;
 
 import io.dingodb.calcite.assertion.Assert;
 import io.dingodb.calcite.assertion.AssertRelNode;
+import io.dingodb.calcite.mock.MockMetaServiceProvider;
 import io.dingodb.calcite.rel.DingoTableScan;
 import lombok.extern.slf4j.Slf4j;
 import org.apache.calcite.plan.Convention;
@@ -54,7 +55,7 @@ public class TestLogicalPlan {
 
     @BeforeAll
     public static void setupAll() {
-        DingoParserContext context = new DingoParserContext();
+        DingoParserContext context = new DingoParserContext(MockMetaServiceProvider.SCHEMA_NAME);
         parser = new DingoParser(context);
     }
 
@@ -76,6 +77,14 @@ public class TestLogicalPlan {
     @Test
     public void testFullScan() throws SqlParseException {
         String sql = "select * from test";
+        RelRoot relRoot = parse(sql);
+        Assert.relNode(relRoot.rel).isA(LogicalProject.class).convention(Convention.NONE)
+            .singleInput().isA(DingoTableScan.class).convention(DingoConventions.DINGO);
+    }
+
+    @Test
+    public void testFullScan1() throws SqlParseException {
+        String sql = "select * from mock.test";
         RelRoot relRoot = parse(sql);
         Assert.relNode(relRoot.rel).isA(LogicalProject.class).convention(Convention.NONE)
             .singleInput().isA(DingoTableScan.class).convention(DingoConventions.DINGO);
@@ -230,7 +239,7 @@ public class TestLogicalPlan {
 
     @Test
     public void testTransfer() throws SqlParseException {
-        String sql = "insert into test1 select id as id1, id as id2, id as id3, name, amount from test";
+        String sql = "insert into mock1.test1 select id as id1, id as id2, id as id3, name, amount from test";
         RelRoot relRoot = parse(sql);
         Assert.relNode(relRoot.rel).isA(LogicalTableModify.class).convention(Convention.NONE)
             .singleInput().isA(LogicalProject.class).convention(Convention.NONE)

--- a/dingo-calcite/src/test/java/io/dingodb/calcite/TestPhysicalPlan.java
+++ b/dingo-calcite/src/test/java/io/dingodb/calcite/TestPhysicalPlan.java
@@ -18,6 +18,7 @@ package io.dingodb.calcite;
 
 import io.dingodb.calcite.assertion.Assert;
 import io.dingodb.calcite.assertion.AssertRelNode;
+import io.dingodb.calcite.mock.MockMetaServiceProvider;
 import io.dingodb.calcite.rel.DingoAggregate;
 import io.dingodb.calcite.rel.DingoCoalesce;
 import io.dingodb.calcite.rel.DingoDistributedValues;
@@ -63,7 +64,7 @@ public class TestPhysicalPlan {
 
     @BeforeAll
     public static void setupAll() {
-        DingoParserContext context = new DingoParserContext();
+        DingoParserContext context = new DingoParserContext(MockMetaServiceProvider.SCHEMA_NAME);
         parser = new DingoParser(context);
     }
 

--- a/dingo-calcite/src/test/java/io/dingodb/calcite/mock/Mock1MetaServiceProvider.java
+++ b/dingo-calcite/src/test/java/io/dingodb/calcite/mock/Mock1MetaServiceProvider.java
@@ -31,10 +31,9 @@ import static org.mockito.ArgumentMatchers.anyString;
 import static org.mockito.Mockito.when;
 
 @AutoService(MetaServiceProvider.class)
-public class MockMetaServiceProvider implements MetaServiceProvider {
-    public static final String SCHEMA_NAME = "MOCK";
+public class Mock1MetaServiceProvider implements MetaServiceProvider {
+    public static final String SCHEMA_NAME = "MOCK1";
 
-    public static final String TABLE_NAME = "TEST";
     public static final String TABLE_1_NAME = "TEST1";
     public static final Location LOC_0 = new Location("host1", 26535, "/path1");
     public static final Location LOC_1 = new Location("host2", 26535, "/path2");
@@ -45,7 +44,6 @@ public class MockMetaServiceProvider implements MetaServiceProvider {
         try {
             when(metaService.getName()).thenReturn(SCHEMA_NAME);
             when(metaService.getTableDefinitions()).thenReturn(ImmutableMap.of(
-                TABLE_NAME, TableDefinition.readJson(getClass().getResourceAsStream("/table-test.json")),
                 TABLE_1_NAME, TableDefinition.readJson(getClass().getResourceAsStream("/table-test1.json"))
             ));
             when(metaService.getTableKey(anyString())).then(args -> {
@@ -55,7 +53,7 @@ public class MockMetaServiceProvider implements MetaServiceProvider {
         } catch (IOException e) {
             e.printStackTrace();
         }
-        when(metaService.getPartLocations(TABLE_NAME)).thenReturn(ImmutableMap.of(
+        when(metaService.getPartLocations(TABLE_1_NAME)).thenReturn(ImmutableMap.of(
             "0", LOC_0,
             "1", LOC_1
         ));

--- a/dingo-calcite/src/test/java/io/dingodb/calcite/visitor/TestRexConverter.java
+++ b/dingo-calcite/src/test/java/io/dingodb/calcite/visitor/TestRexConverter.java
@@ -19,20 +19,13 @@ package io.dingodb.calcite.visitor;
 import com.ibm.icu.impl.Assert;
 import io.dingodb.calcite.DingoParser;
 import io.dingodb.calcite.DingoParserContext;
-import io.dingodb.common.table.TupleSchema;
-import io.dingodb.exec.util.ExprUtil;
+import io.dingodb.calcite.mock.MockMetaServiceProvider;
 import io.dingodb.expr.parser.Expr;
-import io.dingodb.expr.parser.op.FunFactory;
-import io.dingodb.expr.parser.op.Op;
-import io.dingodb.expr.parser.parser.DingoExprCompiler;
 import io.dingodb.expr.runtime.RtExpr;
 import lombok.extern.slf4j.Slf4j;
 import org.apache.calcite.rel.RelRoot;
-import org.apache.calcite.rel.RelWriter;
-import org.apache.calcite.rel.externalize.RelWriterImpl;
 import org.apache.calcite.rel.logical.LogicalProject;
 import org.apache.calcite.rex.RexNode;
-import org.apache.calcite.sql.SqlExplainLevel;
 import org.apache.calcite.sql.SqlNode;
 import org.apache.calcite.sql.parser.SqlParseException;
 import org.junit.jupiter.api.BeforeAll;
@@ -41,15 +34,11 @@ import org.junit.jupiter.params.ParameterizedTest;
 import org.junit.jupiter.params.provider.Arguments;
 import org.junit.jupiter.params.provider.MethodSource;
 
-import java.io.PrintWriter;
 import java.text.ParseException;
-import java.util.ArrayList;
-import java.util.List;
 import java.util.stream.Stream;
 import javax.annotation.Nonnull;
 
 import static org.assertj.core.api.Assertions.assertThat;
-import static org.assertj.core.api.Assertions.in;
 import static org.junit.jupiter.params.provider.Arguments.arguments;
 
 @Slf4j
@@ -58,7 +47,8 @@ public class TestRexConverter {
 
     @BeforeAll
     public static void setupAll() {
-        parser = new DingoParser(new DingoParserContext());
+        DingoParserContext context = new DingoParserContext(MockMetaServiceProvider.SCHEMA_NAME);
+        parser = new DingoParser(context);
     }
 
     @Nonnull
@@ -134,7 +124,7 @@ public class TestRexConverter {
             RexNode rexNode = project.getProjects().get(0);
             Expr expr = RexConverter.convert(rexNode);
             RtExpr rtExpr = expr.compileIn(null);
-            Assert.assrt(((String)(rtExpr.eval(null))).equals(inputStr.replace('\'', ' ').trim()));
+            Assert.assrt(((String) (rtExpr.eval(null))).equals(inputStr.replace('\'', ' ').trim()));
         } catch (Exception ex) {
             ex.printStackTrace();
         }
@@ -151,7 +141,7 @@ public class TestRexConverter {
             RexNode rexNode = project.getProjects().get(0);
             Expr expr = RexConverter.convert(rexNode);
             RtExpr rtExpr = expr.compileIn(null);
-            Assert.assrt(((String)(rtExpr.eval(null))).equals("BB"));
+            Assert.assrt(((String) (rtExpr.eval(null))).equals("BB"));
         } catch (Exception ex) {
             ex.printStackTrace();
         }
@@ -168,7 +158,7 @@ public class TestRexConverter {
             RexNode rexNode = project.getProjects().get(0);
             Expr expr = RexConverter.convert(rexNode);
             RtExpr rtExpr = expr.compileIn(null);
-            Assert.assrt(((String)(rtExpr.eval(null))).equals("BBA"));
+            Assert.assrt(((String) (rtExpr.eval(null))).equals("BBA"));
         } catch (Exception ex) {
             ex.printStackTrace();
         }
@@ -185,7 +175,7 @@ public class TestRexConverter {
             RexNode rexNode = project.getProjects().get(0);
             Expr expr = RexConverter.convert(rexNode);
             RtExpr rtExpr = expr.compileIn(null);
-            Assert.assrt(((String)(rtExpr.eval(null))).equals("ABB"));
+            Assert.assrt(((String) (rtExpr.eval(null))).equals("ABB"));
         } catch (Exception ex) {
             ex.printStackTrace();
         }
@@ -203,7 +193,7 @@ public class TestRexConverter {
             RexNode rexNode = project.getProjects().get(0);
             Expr expr = RexConverter.convert(rexNode);
             RtExpr rtExpr = expr.compileIn(null);
-            Assert.assrt(((String)rtExpr.eval(null)).equals("AAAA "));
+            Assert.assrt(((String) rtExpr.eval(null)).equals("AAAA "));
         } catch (Exception ex) {
             ex.printStackTrace();
         }
@@ -221,7 +211,7 @@ public class TestRexConverter {
             RexNode rexNode = project.getProjects().get(0);
             Expr expr = RexConverter.convert(rexNode);
             RtExpr rtExpr = expr.compileIn(null);
-            Assert.assrt(((String)rtExpr.eval(null)).equals(" AAAA"));
+            Assert.assrt(((String) rtExpr.eval(null)).equals(" AAAA"));
         } catch (Exception ex) {
             ex.printStackTrace();
         }
@@ -238,7 +228,7 @@ public class TestRexConverter {
             RexNode rexNode = project.getProjects().get(0);
             Expr expr = RexConverter.convert(rexNode);
             RtExpr rtExpr = expr.compileIn(null);
-            Assert.assrt(((String)rtExpr.eval(null)).equals("AAA"));
+            Assert.assrt(((String) rtExpr.eval(null)).equals("AAA"));
         } catch (Exception ex) {
             ex.printStackTrace();
         }
@@ -289,7 +279,7 @@ public class TestRexConverter {
             Expr expr = RexConverter.convert(rexNode);
             System.out.println(expr.toString());
             RtExpr rtExpr = expr.compileIn(null);
-            Assert.assrt(((String)rtExpr.eval(null)).equals("CBA"));
+            Assert.assrt(((String) rtExpr.eval(null)).equals("CBA"));
         } catch (Exception ex) {
             ex.printStackTrace();
         }
@@ -344,7 +334,7 @@ public class TestRexConverter {
             System.out.println(expr.toString());
             RtExpr rtExpr = expr.compileIn(null);
             System.out.println(rtExpr.eval(null));
-            Assert.assrt((Integer)(rtExpr.eval(null)) == 2);
+            Assert.assrt((Integer) (rtExpr.eval(null)) == 2);
         } catch (Exception ex) {
             ex.printStackTrace();
         }
@@ -367,7 +357,7 @@ public class TestRexConverter {
             // System.out.println(expr1.toString());
 
             RtExpr rtExpr = expr.compileIn(null);
-            Assert.assrt(((String)rtExpr.eval(null)).equals("AABBCC"));
+            Assert.assrt(((String) rtExpr.eval(null)).equals("AABBCC"));
         } catch (Exception ex) {
             ex.printStackTrace();
         }

--- a/dingo-ddl/src/main/java/io/dingodb/ddl/MutableSchema.java
+++ b/dingo-ddl/src/main/java/io/dingodb/ddl/MutableSchema.java
@@ -18,11 +18,13 @@ package io.dingodb.ddl;
 
 import io.dingodb.common.table.TableDefinition;
 import io.dingodb.meta.MetaService;
+import lombok.Getter;
 import org.apache.calcite.schema.impl.AbstractSchema;
 
 import javax.annotation.Nonnull;
 
 public abstract class MutableSchema extends AbstractSchema {
+    @Getter
     protected final MetaService metaService;
 
     protected MutableSchema(MetaService metaService) {

--- a/dingo-driver/src/main/java/io/dingodb/driver/DingoConnection.java
+++ b/dingo-driver/src/main/java/io/dingodb/driver/DingoConnection.java
@@ -18,6 +18,7 @@ package io.dingodb.driver;
 
 import com.google.common.collect.ImmutableList;
 import io.dingodb.calcite.DingoParserContext;
+import io.dingodb.calcite.DingoRootSchema;
 import lombok.Getter;
 import org.apache.calcite.DataContext;
 import org.apache.calcite.adapter.java.JavaTypeFactory;
@@ -52,7 +53,11 @@ public class DingoConnection extends AvaticaConnection {
         Properties info
     ) {
         super(driver, factory, url, info);
-        context = new DingoParserContext();
+        String defaultSchema = info.getProperty("defaultSchema");
+        if (defaultSchema == null) {
+            defaultSchema = DingoRootSchema.DEFAULT_SCHEMA_NAME;
+        }
+        context = new DingoParserContext(defaultSchema);
     }
 
     public DingoStatement getStatement(@Nonnull Meta.StatementHandle sh) throws SQLException {
@@ -102,7 +107,7 @@ public class DingoConnection extends AvaticaConnection {
 
         @Override
         public List<String> getDefaultSchemaPath() {
-            return ImmutableList.of();
+            return ImmutableList.of(connection.context.getDefaultSchemaName());
         }
 
         @Override

--- a/dingo-exec/src/main/java/io/dingodb/exec/ServiceProvider.java
+++ b/dingo-exec/src/main/java/io/dingodb/exec/ServiceProvider.java
@@ -25,7 +25,7 @@ import java.util.ServiceLoader;
 import javax.annotation.Nonnull;
 import javax.annotation.Nullable;
 
-public final class ServiceProvider<T> {
+public final class ServiceProvider<T> implements Iterable<T> {
     public static final ServiceProvider<StoreServiceProvider> KV_STORE_PROVIDER
         = new ServiceProvider<>(StoreServiceProvider.class);
     public static final ServiceProvider<MetaServiceProvider> META_PROVIDER
@@ -56,5 +56,11 @@ public final class ServiceProvider<T> {
     @Nullable
     public T provider() {
         return provider(false);
+    }
+
+    @Nonnull
+    @Override
+    public Iterator<T> iterator() {
+        return providers(false);
     }
 }

--- a/dingo-meta-api/src/main/java/io/dingodb/meta/MetaService.java
+++ b/dingo-meta-api/src/main/java/io/dingodb/meta/MetaService.java
@@ -23,6 +23,8 @@ import javax.annotation.Nonnull;
 import javax.annotation.Nullable;
 
 public interface MetaService {
+    String getName();
+
     void init(@Nullable Map<String, Object> props);
 
     void clear();

--- a/dingo-server/client/src/main/java/io/dingodb/server/client/meta/service/MetaServiceClient.java
+++ b/dingo-server/client/src/main/java/io/dingodb/server/client/meta/service/MetaServiceClient.java
@@ -62,6 +62,11 @@ public class MetaServiceClient implements MetaService {
     }
 
     @Override
+    public String getName() {
+        return "DINGO";
+    }
+
+    @Override
     public void init(@Nullable Map<String, Object> props) {
 
     }

--- a/dingo-server/coordinator/src/main/java/io/dingodb/server/coordinator/meta/service/CoordinatorMetaService.java
+++ b/dingo-server/coordinator/src/main/java/io/dingodb/server/coordinator/meta/service/CoordinatorMetaService.java
@@ -77,6 +77,11 @@ public class CoordinatorMetaService implements MetaService, MetaServiceApi {
     }
 
     @Override
+    public String getName() {
+        return "DINGO";
+    }
+
+    @Override
     public void createTable(@Nonnull String tableName, @Nonnull TableDefinition tableDefinition) {
         if (!isCoordinatorLeader()) {
             throw new RuntimeException("Only coordinator leader create table.");

--- a/dingo-test/src/main/java/io/dingodb/example/DingoDriverExample.java
+++ b/dingo-test/src/main/java/io/dingodb/example/DingoDriverExample.java
@@ -32,9 +32,8 @@ import java.util.List;
 import java.util.Map;
 
 public class DingoDriverExample {
-    private static Logger log = LoggerFactory.getLogger(DingoDriverExample.class);
-
     private static final String defaultConnectIp = "172.20.3.13";
+    private static Logger log = LoggerFactory.getLogger(DingoDriverExample.class);
     private static String connectUrl = "url=http://" + defaultConnectIp + ":8765";
     private static Connection connection;
 
@@ -62,10 +61,10 @@ public class DingoDriverExample {
             statement = connection.createStatement();
         } catch (ClassNotFoundException ex) {
             log.info("Init driver catch ClassNotFoundExeption:{}", ex.toString(), ex);
-            return ;
+            return;
         } catch (SQLException ex) {
             log.info("Init driver catch SQLException:{}", ex.toString(), ex);
-            return ;
+            return;
         }
 
         Long recordCnt = 100L;
@@ -118,7 +117,7 @@ public class DingoDriverExample {
         final Long endTime = System.currentTimeMillis();
         System.out.println("Current Command:" + command
             + ", RecordCnt:" + recordCnt
-            + ", AvgCost:" + (endTime - startTime) /  recordCnt
+            + ", AvgCost:" + (endTime - startTime) / recordCnt
             + "ms, totalCnt:" + recordCnt
             + ", batchCnt:" + batchCnt);
     }
@@ -171,7 +170,7 @@ public class DingoDriverExample {
     }
 
     private static int getRandomInt(int min, int max) {
-        return min + (int)(Math.random() * ((max - min) + 1));
+        return min + (int) (Math.random() * ((max - min) + 1));
     }
 
     private static double getRandomDouble(int min, int max) {

--- a/dingo-test/src/main/java/io/dingodb/meta/test/MetaTestService.java
+++ b/dingo-test/src/main/java/io/dingodb/meta/test/MetaTestService.java
@@ -44,6 +44,8 @@ import javax.annotation.Nullable;
 
 @Slf4j
 public class MetaTestService implements MetaService {
+    public static final String SCHEMA_NAME = "TEST";
+
     public static final MetaTestService INSTANCE = new MetaTestService();
     public static final String PROP_PATH = "path";
     private File path;
@@ -70,6 +72,11 @@ public class MetaTestService implements MetaService {
     @Nonnull
     private File metaFile(@Nonnull String tableName) {
         return new File(path, tableName.toLowerCase().replace(".", File.separator) + ".json");
+    }
+
+    @Override
+    public String getName() {
+        return SCHEMA_NAME;
     }
 
     @Override


### PR DESCRIPTION
Now there can be multiple meta services named by its `getName()` method.