### PR TITLE
Hotfix default values when table create

### DIFF
--- a/dingo-calcite/src/main/java/io/dingodb/calcite/DingoInitializerExpressionFactory.java
+++ b/dingo-calcite/src/main/java/io/dingodb/calcite/DingoInitializerExpressionFactory.java
@@ -69,6 +69,10 @@ class DingoInitializerExpressionFactory extends NullInitializerExpressionFactory
          * if default value is function, we need to call function to get value
          */
         try {
+            /**
+             * discard the special character "`" imported by MySQL dialect.
+             */
+            defaultValue = defaultValue.toString().trim().replace('`', ' ').trim();
             Expr expr = DingoExprCompiler.parse(defaultValue.toString());
             if (expr instanceof Var) {
                 expr = DingoExprCompiler.parse(defaultValue.toString().trim() + "()");
@@ -154,26 +158,4 @@ class DingoInitializerExpressionFactory extends NullInitializerExpressionFactory
         return defaultValue;
     }
 
-    private Method getMatchMethod(final List<Method> methods,
-                                  final Object[] args) throws IllegalArgumentException {
-        boolean isMatch = false;
-        Method foundMethod = null;
-        for (Method method : methods) {
-            // just like current_date
-            if ((args == null || args.length == 0) && method.getParameterCount() == 0) {
-                isMatch = true;
-                foundMethod = method;
-                break;
-            }
-
-            if (method.getGenericParameterTypes().length != args.length) {
-                continue;
-            }
-
-            // Nowly, we only support function without paramerter
-            // check if the parameter type is match
-        }
-
-        return isMatch ? foundMethod : null;
-    }
 }

--- a/dingo-calcite/src/main/java/io/dingodb/calcite/DingoParser.java
+++ b/dingo-calcite/src/main/java/io/dingodb/calcite/DingoParser.java
@@ -104,8 +104,9 @@ public class DingoParser {
         );
 
         // CatalogReader is also serving as SqlOperatorTable
+        SqlStdOperatorTable tableInstance = SqlStdOperatorTable.instance();
         sqlValidator = SqlValidatorUtil.newValidator(
-            SqlOperatorTables.chain(SqlStdOperatorTable.instance(), catalogReader),
+            SqlOperatorTables.chain(tableInstance, catalogReader),
             catalogReader,
             context.getTypeFactory(),
             validatorConfig

--- a/dingo-calcite/src/main/java/io/dingodb/calcite/DingoParserContext.java
+++ b/dingo-calcite/src/main/java/io/dingodb/calcite/DingoParserContext.java
@@ -22,6 +22,7 @@ import org.apache.calcite.jdbc.CalciteSchema;
 import org.apache.calcite.jdbc.JavaTypeFactoryImpl;
 import org.apache.calcite.schema.impl.ScalarFunctionImpl;
 
+
 // These are static for every sql parsing.
 public final class DingoParserContext {
     @Getter
@@ -49,12 +50,6 @@ public final class DingoParserContext {
         DingoFunctions.getInstance().getDingoFunctions().forEach(method -> {
             rootSchema.plus().add(method.getName().toUpperCase(), ScalarFunctionImpl.create(method.getMethod()));
         });
-
-        /*
-        DingoFunc.DINGO_FUNC_LIST.build().forEach((k, v) -> {
-            rootSchema.plus().add(k, ScalarFunctionImpl.create(DingoFunc.class, v));
-        });
-       */
     }
 
     public CalciteSchema getDefaultSchema() {

--- a/dingo-calcite/src/test/java/io/dingodb/calcite/visitor/TestRexConverter.java
+++ b/dingo-calcite/src/test/java/io/dingodb/calcite/visitor/TestRexConverter.java
@@ -647,8 +647,7 @@ public class TestRexConverter {
 
     @Test
     public void testStringConcat() throws Exception {
-        String sql = "select 'AA' || 'BB' || 'CC' ";
-        // String sql = "select concat('AA', 'BB', 'CC') ";
+        String sql = "select concat(concat('AA', 'BB'), 'CC')";
         SqlNode sqlNode = parser.parse(sql);
         sqlNode = parser.validate(sqlNode);
         RelRoot relRoot = parser.convert(sqlNode);
@@ -657,9 +656,20 @@ public class TestRexConverter {
         Expr expr = RexConverter.convert(rexNode);
         System.out.println(expr.toString());
 
-        // Expr expr1 = DingoExprCompiler.parse("concat('A', 'B')");
-        // System.out.println(expr1.toString());
+        RtExpr rtExpr = expr.compileIn(null);
+        Assert.assrt(rtExpr.eval(null).equals("AABBCC"));
+    }
 
+    @Test
+    public void testStringConcat01() throws Exception {
+        String sql = "select 'AA' || 'BB' || 'CC' ";
+        SqlNode sqlNode = parser.parse(sql);
+        sqlNode = parser.validate(sqlNode);
+        RelRoot relRoot = parser.convert(sqlNode);
+        LogicalProject project = (LogicalProject) relRoot.rel;
+        RexNode rexNode = project.getProjects().get(0);
+        Expr expr = RexConverter.convert(rexNode);
+        System.out.println(expr.toString());
         RtExpr rtExpr = expr.compileIn(null);
         Assert.assrt(rtExpr.eval(null).equals("AABBCC"));
     }

--- a/dingo-common/build.gradle
+++ b/dingo-common/build.gradle
@@ -21,6 +21,7 @@ plugins {
 
 dependencies {
     api group: 'org.apache.avro', name: 'avro', version: 'avro'.v()
+    api project(':dingo-expr:dingo-expr-parser')
     api project(':dingo-expr:dingo-expr-json-runtime')
     api project(':dingo-expr:dingo-expr-runtime')
     implementation group: 'org.apache.calcite', name: 'calcite-core', version: 'calcite'.v()

--- a/dingo-common/src/main/java/io/dingodb/common/table/ColumnDefinition.java
+++ b/dingo-common/src/main/java/io/dingodb/common/table/ColumnDefinition.java
@@ -29,6 +29,7 @@ import lombok.Builder;
 import lombok.EqualsAndHashCode;
 import lombok.Getter;
 import lombok.NonNull;
+import lombok.extern.slf4j.Slf4j;
 import org.apache.calcite.rel.type.RelDataType;
 import org.apache.calcite.rel.type.RelDataTypeFactory;
 import org.apache.calcite.schema.ColumnStrategy;
@@ -39,6 +40,7 @@ import javax.annotation.Nonnull;
 @JsonPropertyOrder({"name", "type", "precision", "scale", "nullable", "primary", "default"})
 @EqualsAndHashCode
 @Builder
+@Slf4j
 public class ColumnDefinition {
     @JsonProperty(value = "name", required = true)
     @Getter
@@ -81,7 +83,7 @@ public class ColumnDefinition {
     @JsonInclude(JsonInclude.Include.NON_DEFAULT)
     @Getter
     @Builder.Default
-    private final Object defaultValue = null;
+    private final String defaultValue = null;
 
     @JsonCreator
     public static ColumnDefinition getInstance(
@@ -102,7 +104,7 @@ public class ColumnDefinition {
                 .scale(scale != null ? scale : RelDataType.SCALE_NOT_SPECIFIED)
                 .notNull(notNull)
                 .primary(primary)
-                .defaultValue(defaultValue)
+                .defaultValue(defaultValue != null ? defaultValue.toString() : null)
                 .build();
         }
         throw new AssertionError("Invalid type name \"" + typeName + "\".");

--- a/dingo-common/src/main/java/io/dingodb/common/util/DateUtils.java
+++ b/dingo-common/src/main/java/io/dingodb/common/util/DateUtils.java
@@ -1,0 +1,57 @@
+/*
+ * Copyright 2021 DataCanvas
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package io.dingodb.common.util;
+
+public final class DateUtils {
+
+    /**
+     * getEpochDay is a utility method that returns the number of days since the epoch.
+     * @param input milliseconds since the epoch
+     * @return int
+     */
+    public static int getEpochDay(Object input) {
+        Long timestamp = 0L;
+        if (input instanceof Number) {
+            timestamp = ((Number) input).longValue();
+        } else if (input instanceof java.sql.Date) {
+            timestamp = ((java.sql.Date) input).getTime();
+        }
+        return (int) (timestamp / (1000 * 60 * 60 * 24));
+    }
+
+    public static int getEpochTime(Object input) {
+        Long timestamp = 0L;
+        if (input instanceof Number) {
+            timestamp = ((Number) input).longValue();
+        } else if (input instanceof java.sql.Time) {
+            // current_time will return a java.sql.Time object
+            timestamp = ((java.sql.Time) input).getTime();
+        }
+        return (int) (timestamp % (1000 * 60 * 60 * 24));
+    }
+
+    public static long getTimestampValueByCalcite(Object input) {
+        Long timeStamp = 0L;
+        if (input instanceof Number) {
+            timeStamp = ((Number) input).longValue();
+        } else if (input instanceof java.sql.Timestamp) {
+            timeStamp = ((java.sql.Timestamp) input).getTime();
+        }
+        return timeStamp;
+    }
+
+}

--- a/dingo-ddl/src/main/java/io/dingodb/ddl/DingoDdlExecutor.java
+++ b/dingo-ddl/src/main/java/io/dingodb/ddl/DingoDdlExecutor.java
@@ -18,6 +18,9 @@ package io.dingodb.ddl;
 
 import io.dingodb.common.table.ColumnDefinition;
 import io.dingodb.common.table.TableDefinition;
+import io.dingodb.expr.parser.Expr;
+import io.dingodb.expr.parser.exception.DingoExprParseException;
+import io.dingodb.expr.parser.parser.DingoExprCompiler;
 import lombok.extern.slf4j.Slf4j;
 import org.apache.calcite.jdbc.CalcitePrepare;
 import org.apache.calcite.jdbc.CalciteSchema;
@@ -79,18 +82,19 @@ public class DingoDdlExecutor extends DdlExecutorImpl {
         SqlTypeName typeName = dataType.getSqlTypeName();
         int precision = typeName.allowsPrec() ? dataType.getPrecision() : RelDataType.PRECISION_NOT_SPECIFIED;
         int scale = typeName.allowsScale() ? dataType.getScale() : RelDataType.SCALE_NOT_SPECIFIED;
-        Object defaultValue = null;
+        String defaultValue = "";
         ColumnStrategy strategy = scd.strategy;
         if (strategy == ColumnStrategy.DEFAULT) {
             SqlNode expr = scd.expression;
             if (expr instanceof SqlLiteral) {
-                defaultValue = ((SqlLiteral) expr).getValue();
+                defaultValue = ((SqlLiteral) expr).getValue().toString();
             }
             // case like: current_date(SqlIdentifier) or current_date()(SqlIdentifier)
             if (expr instanceof SqlIdentifier || expr instanceof SqlBasicCall) {
-                defaultValue = expr;
+                defaultValue = expr.toString();
             }
         }
+
         String name = scd.name.getSimple();
         boolean isPrimary = (primaryKeyList != null && primaryKeyList.contains(name));
         return ColumnDefinition.builder()

--- a/dingo-driver/src/main/java/io/dingodb/driver/DingoMeta.java
+++ b/dingo-driver/src/main/java/io/dingodb/driver/DingoMeta.java
@@ -18,6 +18,7 @@ package io.dingodb.driver;
 
 import com.google.common.collect.ImmutableList;
 import io.dingodb.calcite.DingoParserContext;
+import io.dingodb.common.util.DateUtils;
 import io.dingodb.exec.operator.RootOperator;
 import lombok.extern.slf4j.Slf4j;
 import org.apache.calcite.avatica.AvaticaUtils;
@@ -224,36 +225,15 @@ public class DingoMeta extends MetaImpl {
         }
         switch (columnClassName) {
             case "java.sql.date": {
-                Long timeStamp = 0L;
-                if (input instanceof Number) {
-                    timeStamp = ((Number) input).longValue();
-                } else if (input instanceof java.sql.Date) {
-                    timeStamp = ((java.sql.Date) input).getTime();
-                }
-                Long epochTime = timeStamp / (24 * 60 * 60 * 1000);
-                valueAfterCvt = epochTime;
+                valueAfterCvt = Long.valueOf(DateUtils.getEpochDay(input));
                 break;
             }
             case "java.sql.time": {
-                Long timeStamp = 0L;
-                if (input instanceof Number) {
-                    timeStamp = ((Number) input).longValue();
-                } else if (input instanceof java.sql.Time) {
-                    // current_time will return a java.sql.Time object
-                    timeStamp = ((java.sql.Time) input).getTime();
-                }
-                timeStamp %= (24 * 60 * 60 * 1000);
-                valueAfterCvt = timeStamp;
+                valueAfterCvt = Long.valueOf(DateUtils.getEpochTime(input));
                 break;
             }
             case "java.sql.timestamp": {
-                Long timeStamp = 0L;
-                if (input instanceof Number) {
-                    timeStamp = ((Number) input).longValue();
-                } else if (input instanceof java.sql.Timestamp) {
-                    timeStamp = ((java.sql.Timestamp) input).getTime();
-                }
-                valueAfterCvt = timeStamp;
+                valueAfterCvt = DateUtils.getTimestampValueByCalcite(input);
                 break;
             }
             case "java.lang.integer": {

--- a/dingo-server/coordinator/src/main/java/io/dingodb/server/coordinator/meta/adaptor/impl/TableAdaptor.java
+++ b/dingo-server/coordinator/src/main/java/io/dingodb/server/coordinator/meta/adaptor/impl/TableAdaptor.java
@@ -93,6 +93,14 @@ public class TableAdaptor extends BaseAdaptor<Table> {
             .map(columnDefinition -> definitionToMeta(table, columnDefinition))
             .peek(column -> column.setId(columnAdaptor.newId(column)))
             .collect(Collectors.toList());
+
+        if (log.isDebugEnabled()) {
+            log.debug("receive create tableName:{} definition:{}, after convert columns:{}",
+                table.getName(),
+                definition,
+                columns.stream().map(Column::toString).collect(Collectors.joining("\n")));
+        }
+
         columns.stream()
             .map(column -> new KeyValue(column.getId().encode(), columnAdaptor.encodeMeta(column)))
             .forEach(keyValues::add);
@@ -187,6 +195,9 @@ public class TableAdaptor extends BaseAdaptor<Table> {
             .map(this::metaToDefinition)
             .collect(Collectors.toList());
         tableDefinition.setColumns(columnDefinitions);
+        if (log.isDebugEnabled()) {
+            log.info("Meta to table definition: {}", tableDefinition);
+        }
         return tableDefinition;
     }
 
@@ -198,6 +209,7 @@ public class TableAdaptor extends BaseAdaptor<Table> {
             .primary(column.isPrimary())
             .scale(column.getScale())
             .type(SqlTypeName.get(column.getType()))
+            .defaultValue(column.getDefaultValue())
             .build();
     }
 
@@ -216,6 +228,7 @@ public class TableAdaptor extends BaseAdaptor<Table> {
             .notNull(definition.isNotNull())
             .table(table.getId())
             .schema(table.getSchema())
+            .defaultValue(definition.getDefaultValue())
             .build();
     }
 

--- a/dingo-server/coordinator/src/main/java/io/dingodb/server/coordinator/meta/service/DingoMetaService.java
+++ b/dingo-server/coordinator/src/main/java/io/dingodb/server/coordinator/meta/service/DingoMetaService.java
@@ -89,7 +89,6 @@ public class DingoMetaService implements MetaService, MetaServiceApi {
     @Override
     public void createTable(@Nonnull String tableName, @Nonnull TableDefinition tableDefinition) {
         ((TableAdaptor) getMetaAdaptor(Table.class)).create(DINGO_ID, tableDefinition);
-
     }
 
     @Override

--- a/dingo-server/protocol/src/main/java/io/dingodb/server/protocol/meta/Column.java
+++ b/dingo-server/protocol/src/main/java/io/dingodb/server/protocol/meta/Column.java
@@ -50,6 +50,6 @@ public class Column implements Meta {
     private int precision;
     private String type;
     private int version;
-    private Object defaultValue;
+    private String defaultValue;
 
 }

--- a/dingo-test/src/test/java/io/dingodb/test/TableWithDefaultValueTest.java
+++ b/dingo-test/src/test/java/io/dingodb/test/TableWithDefaultValueTest.java
@@ -173,6 +173,27 @@ public class TableWithDefaultValueTest {
     }
 
     @Test
+    public void testCaseDefaultValueIsNull() throws Exception {
+        String tableName = "testDefaultValueIsNull";
+        final String sqlCmd = "create table " + tableName + " (\n"
+            + "    id int not null,\n"
+            + "    name varchar(32) not null,\n"
+            + "    age int null default 20,\n"
+            + " primary key(id))\n";
+        sqlHelper.execSqlCmd(sqlCmd);
+
+        String sql = "insert into " + tableName + " (id, name) values (100, 'lala')";
+        sqlHelper.execSqlCmd(sql);
+
+        sql = "select * from " + tableName;
+        sqlHelper.queryTest(sql,
+            new String[]{"id", "name", "age"},
+            TupleSchema.ofTypes("INTEGER", "STRING", "INTEGER", "DOUBLE", "STRING"),
+            "100, lala, 20");
+        sqlHelper.clearTable(tableName);
+    }
+
+    @Test
     public void testCase05() throws Exception {
         List<String> inputDateFuncList = Arrays.asList(
             "current_date",

--- a/dingo-test/src/test/java/io/dingodb/test/TableWithDefaultValueTest.java
+++ b/dingo-test/src/test/java/io/dingodb/test/TableWithDefaultValueTest.java
@@ -311,28 +311,44 @@ public class TableWithDefaultValueTest {
     @Test
     public void testCase08() throws Exception {
         String tableName = "testCase08";
-        try {
-            final String sqlCmd = "create table " + tableName + " (\n"
-                + "    id int,\n"
-                + "    name varchar(32) not null,\n"
-                + "    address varchar(32) default lcase('ABC'), \n"
-                + "    primary key(id)\n"
-                + ")\n";
-            sqlHelper.execSqlCmd(sqlCmd);
-            String sql = "insert into " + tableName + " (id, name) values (100, 'lala')";
-            sqlHelper.updateTest(sql, 1);
+        final String sqlCmd = "create table " + tableName + " (\n"
+            + "    id int,\n"
+            + "    name varchar(32) not null,\n"
+            + "    address varchar(32) default lcase('ABC'), \n"
+            + "    primary key(id)\n"
+            + ")\n";
+        sqlHelper.execSqlCmd(sqlCmd);
+        String sql = "insert into " + tableName + " (id, name) values (100, 'lala')";
+        sqlHelper.updateTest(sql, 1);
 
-            String expectRecord = "100, lala, abc";
-            sql = "select * from " + tableName;
-            sqlHelper.queryTest(sql,
-                new String[]{"id", "name", "address"},
-                TupleSchema.ofTypes("INTEGER", "STRING", "STRING"),
-                expectRecord);
-        } catch (SQLException ex) {
-            assertTrue(ex.getMessage().contains("cannot be cast"));
-        } finally {
-            sqlHelper.clearTable(tableName);
-        }
+        String expectRecord = "100, lala, abc";
+        sql = "select * from " + tableName;
+        sqlHelper.queryTest(sql,
+            new String[]{"id", "name", "address"},
+            TupleSchema.ofTypes("INTEGER", "STRING", "STRING"),
+            expectRecord);
+        sqlHelper.clearTable(tableName);
+    }
 
+    @Test
+    public void testCase09() throws Exception {
+        String tableName = "testCase09";
+        final String sqlCmd = "create table " + tableName + " (\n"
+            + "    id int,\n"
+            + "    name varchar(32) not null,\n"
+            + "    address varchar(32) default concat('AAA','BBB'), \n"
+            + "    primary key(id)\n"
+            + ")\n";
+        sqlHelper.execSqlCmd(sqlCmd);
+        String sql = "insert into " + tableName + " (id, name) values (100, 'lala')";
+        sqlHelper.updateTest(sql, 1);
+
+        String expectRecord = "100, lala, AAABBB";
+        sql = "select * from " + tableName;
+        sqlHelper.queryTest(sql,
+            new String[]{"id", "name", "address"},
+            TupleSchema.ofTypes("INTEGER", "STRING", "STRING"),
+            expectRecord);
+        sqlHelper.clearTable(tableName);
     }
 }


### PR DESCRIPTION
1. Hotfix bugs when assigning default values for a column.
2. Support default value from const functions such as `current_date`, `current_timestamp`, `now`, const expression
3. add the `Concat` function to connect two strings as a new string