### PR TITLE
[dingo-calcite] Fixed #219: HashJoin returns wrong result set.

### DIFF
--- a/dingo-calcite/src/main/java/io/dingodb/calcite/rel/DingoDistributedValues.java
+++ b/dingo-calcite/src/main/java/io/dingodb/calcite/rel/DingoDistributedValues.java
@@ -22,6 +22,7 @@ import lombok.Getter;
 import org.apache.calcite.plan.RelOptCluster;
 import org.apache.calcite.plan.RelOptTable;
 import org.apache.calcite.plan.RelTraitSet;
+import org.apache.calcite.rel.RelWriter;
 import org.apache.calcite.rel.type.RelDataType;
 import org.apache.calcite.rex.RexLiteral;
 
@@ -40,6 +41,14 @@ public class DingoDistributedValues extends DingoValues {
     ) {
         super(cluster, rowType, tuples, traits);
         this.table = table;
+    }
+
+    @Nonnull
+    @Override
+    public RelWriter explainTerms(RelWriter pw) {
+        super.explainTerms(pw);
+        pw.item("table", table);
+        return pw;
     }
 
     @Override

--- a/dingo-calcite/src/main/java/io/dingodb/calcite/rel/DingoGetByKeys.java
+++ b/dingo-calcite/src/main/java/io/dingodb/calcite/rel/DingoGetByKeys.java
@@ -26,6 +26,7 @@ import org.apache.calcite.plan.RelOptPlanner;
 import org.apache.calcite.plan.RelOptTable;
 import org.apache.calcite.plan.RelTraitSet;
 import org.apache.calcite.rel.AbstractRelNode;
+import org.apache.calcite.rel.RelWriter;
 import org.apache.calcite.rel.metadata.RelMetadataQuery;
 import org.apache.calcite.rel.type.RelDataType;
 import org.checkerframework.checker.nullness.qual.Nullable;
@@ -66,6 +67,16 @@ public final class DingoGetByKeys extends AbstractRelNode implements DingoRel {
         double cpu = rowCount + 1;
         double io = 0;
         return planner.getCostFactory().makeCost(rowCount, cpu, io);
+    }
+
+    @Nonnull
+    @Override
+    public RelWriter explainTerms(RelWriter pw) {
+        super.explainTerms(pw);
+        pw.item("table", table);
+        pw.item("keyTuples", keyTuples);
+        pw.item("selection", selection);
+        return pw;
     }
 
     @Override

--- a/dingo-calcite/src/main/java/io/dingodb/calcite/rel/DingoHash.java
+++ b/dingo-calcite/src/main/java/io/dingodb/calcite/rel/DingoHash.java
@@ -22,6 +22,7 @@ import org.apache.calcite.plan.RelOptCluster;
 import org.apache.calcite.plan.RelTraitSet;
 import org.apache.calcite.rel.AbstractRelNode;
 import org.apache.calcite.rel.RelNode;
+import org.apache.calcite.rel.RelWriter;
 import org.apache.calcite.rel.SingleRel;
 import org.apache.calcite.rel.type.RelDataType;
 
@@ -46,6 +47,15 @@ public final class DingoHash extends SingleRel implements DingoRel {
     @Override
     public RelNode copy(RelTraitSet traitSet, List<RelNode> inputs) {
         return new DingoHash(getCluster(), traitSet, AbstractRelNode.sole(inputs), keys);
+    }
+
+    @Nonnull
+    @Override
+    public RelWriter explainTerms(RelWriter pw) {
+        super.explainTerms(pw);
+        // crucial, this is how Calcite distinguish between different node with different props.
+        pw.itemIf("keys", keys, keys != null);
+        return pw;
     }
 
     @Override

--- a/dingo-calcite/src/main/java/io/dingodb/calcite/rel/DingoPartDelete.java
+++ b/dingo-calcite/src/main/java/io/dingodb/calcite/rel/DingoPartDelete.java
@@ -26,17 +26,13 @@ import org.apache.calcite.plan.RelOptTable;
 import org.apache.calcite.plan.RelOptUtil;
 import org.apache.calcite.plan.RelTraitSet;
 import org.apache.calcite.rel.AbstractRelNode;
-import org.apache.calcite.rel.RelNode;
-import org.apache.calcite.rel.SingleRel;
-import org.apache.calcite.rel.core.TableModify;
+import org.apache.calcite.rel.RelWriter;
 import org.apache.calcite.rel.metadata.RelMetadataQuery;
 import org.apache.calcite.rel.type.RelDataType;
-import org.apache.calcite.rex.RexNode;
 import org.apache.calcite.sql.SqlKind;
 import org.checkerframework.checker.nullness.qual.Nullable;
 
 import javax.annotation.Nonnull;
-import java.util.List;
 
 public final class DingoPartDelete extends AbstractRelNode implements DingoRel {
     @Getter
@@ -61,10 +57,18 @@ public final class DingoPartDelete extends AbstractRelNode implements DingoRel {
         return RelOptUtil.createDmlRowType(SqlKind.INSERT, getCluster().getTypeFactory());
     }
 
-
     @Override
     public @Nullable RelOptCost computeSelfCost(RelOptPlanner planner, RelMetadataQuery mq) {
         return planner.getCostFactory().makeCost(0, 0, 0);
+    }
+
+    @Nonnull
+    @Override
+    public RelWriter explainTerms(RelWriter pw) {
+        super.explainTerms(pw);
+        pw.item("table", table);
+        pw.item("tupleMapping", tupleMapping);
+        return pw;
     }
 
     @Override

--- a/dingo-calcite/src/main/java/io/dingodb/calcite/rel/DingoPartModify.java
+++ b/dingo-calcite/src/main/java/io/dingodb/calcite/rel/DingoPartModify.java
@@ -23,6 +23,7 @@ import org.apache.calcite.plan.RelOptTable;
 import org.apache.calcite.plan.RelOptUtil;
 import org.apache.calcite.plan.RelTraitSet;
 import org.apache.calcite.rel.RelNode;
+import org.apache.calcite.rel.RelWriter;
 import org.apache.calcite.rel.SingleRel;
 import org.apache.calcite.rel.core.TableModify;
 import org.apache.calcite.rel.type.RelDataType;
@@ -75,6 +76,17 @@ public final class DingoPartModify extends SingleRel implements DingoRel {
             getUpdateColumnList(),
             getSourceExpressionList()
         );
+    }
+
+    @Nonnull
+    @Override
+    public RelWriter explainTerms(RelWriter pw) {
+        super.explainTerms(pw);
+        pw.item("table", table);
+        pw.item("operation", operation);
+        pw.item("updateColumnList", updateColumnList);
+        pw.item("sourceExpressionList", sourceExpressionList);
+        return pw;
     }
 
     @Override

--- a/dingo-calcite/src/main/java/io/dingodb/calcite/rel/DingoPartition.java
+++ b/dingo-calcite/src/main/java/io/dingodb/calcite/rel/DingoPartition.java
@@ -23,6 +23,7 @@ import org.apache.calcite.plan.RelOptTable;
 import org.apache.calcite.plan.RelTraitSet;
 import org.apache.calcite.rel.AbstractRelNode;
 import org.apache.calcite.rel.RelNode;
+import org.apache.calcite.rel.RelWriter;
 import org.apache.calcite.rel.SingleRel;
 
 import java.util.List;
@@ -41,6 +42,14 @@ public final class DingoPartition extends SingleRel implements DingoRel {
     @Override
     public RelNode copy(RelTraitSet traitSet, List<RelNode> inputs) {
         return new DingoPartition(getCluster(), traitSet, AbstractRelNode.sole(inputs), table);
+    }
+
+    @Nonnull
+    @Override
+    public RelWriter explainTerms(RelWriter pw) {
+        super.explainTerms(pw);
+        pw.item("table", table);
+        return pw;
     }
 
     @Override

--- a/dingo-calcite/src/main/java/io/dingodb/calcite/rel/DingoReduce.java
+++ b/dingo-calcite/src/main/java/io/dingodb/calcite/rel/DingoReduce.java
@@ -21,6 +21,7 @@ import lombok.Getter;
 import org.apache.calcite.plan.RelOptCluster;
 import org.apache.calcite.plan.RelTraitSet;
 import org.apache.calcite.rel.RelNode;
+import org.apache.calcite.rel.RelWriter;
 import org.apache.calcite.rel.SingleRel;
 import org.apache.calcite.rel.core.AggregateCall;
 import org.apache.calcite.rel.type.RelDataType;
@@ -67,6 +68,16 @@ public final class DingoReduce extends SingleRel implements DingoRel {
             aggregateCallList,
             originalInputType
         );
+    }
+
+    @Nonnull
+    @Override
+    public RelWriter explainTerms(RelWriter pw) {
+        super.explainTerms(pw);
+        pw.item("groupSet", groupSet);
+        pw.item("aggregateCallList", aggregateCallList);
+        pw.item("originalInputType", originalInputType);
+        return pw;
     }
 
     @Override

--- a/dingo-expr/runtime/src/main/java/io/dingodb/expr/runtime/evaluator/arithmetic/ArithmeticEvaluators.java
+++ b/dingo-expr/runtime/src/main/java/io/dingodb/expr/runtime/evaluator/arithmetic/ArithmeticEvaluators.java
@@ -29,6 +29,8 @@ import io.dingodb.expr.runtime.evaluator.base.StringEvaluator;
 import io.dingodb.expr.runtime.evaluator.base.TimeEvaluator;
 import io.dingodb.expr.runtime.evaluator.base.TimestampEvaluator;
 import io.dingodb.expr.runtime.evaluator.base.UniversalEvaluator;
+import io.dingodb.expr.runtime.evaluator.utils.Time2StringUtils;
+import lombok.extern.slf4j.Slf4j;
 
 import java.math.BigDecimal;
 import java.math.RoundingMode;
@@ -37,6 +39,7 @@ import java.sql.Time;
 import java.sql.Timestamp;
 import javax.annotation.Nonnull;
 
+@Slf4j
 @Evaluators(
     evaluatorKey = EvaluatorKey.class,
     evaluatorBase = Evaluator.class,
@@ -222,6 +225,38 @@ final class ArithmeticEvaluators {
         return value0.compareTo(value1) <= 0 ? value0 : value1;
     }
 
+    // This is not arithmetic op, but put here to share the same evaluator factory.
+    @Evaluators.Base(StringEvaluator.class)
+    static String min(@Nonnull String value0, String value1) {
+        return value0.compareTo(value1) <= 0 ? value0 : value1;
+    }
+
+    // This is not arithmetic op, but put here to share the same evaluator factory.
+    @Evaluators.Base(DateEvaluator.class)
+    static Date min(@Nonnull Date value0, Date value1) {
+        return value0.compareTo(value1) <= 0 ? value0 : value1;
+    }
+
+    // This is not arithmetic op, but put here to share the same evaluator factory.
+    @Nonnull
+    @Evaluators.Base(TimeEvaluator.class)
+    static Time min(@Nonnull Time value0, @Nonnull Time value1) {
+        if (log.isDebugEnabled()) {
+            log.debug(
+                "min({}, {}):Time called.",
+                Time2StringUtils.toGmtString(value0),
+                Time2StringUtils.toGmtString(value1)
+            );
+        }
+        return value0.compareTo(value1) <= 0 ? value0 : value1;
+    }
+
+    // This is not arithmetic op, but put here to share the same evaluator factory.
+    @Evaluators.Base(TimestampEvaluator.class)
+    static Timestamp min(@Nonnull Timestamp value0, Timestamp value1) {
+        return value0.compareTo(value1) < 0 ? value0 : value1;
+    }
+
     @Evaluators.Base(IntegerEvaluator.class)
     static int max(int value0, int value1) {
         return Math.max(value0, value1);
@@ -242,49 +277,33 @@ final class ArithmeticEvaluators {
         return value0.compareTo(value1) >= 0 ? value0 : value1;
     }
 
-    /**
-     * These are string op, put here to share the same evaluator factory.
-     */
-
-    @Evaluators.Base(StringEvaluator.class)
-    static String min(@Nonnull String value0, String value1) {
-        return value0.compareTo(value1) <= 0 ? value0 : value1;
-    }
-
+    // This is not arithmetic op, but put here to share the same evaluator factory.
     @Evaluators.Base(StringEvaluator.class)
     static String max(@Nonnull String value0, String value1) {
         return value0.compareTo(value1) >= 0 ? value0 : value1;
     }
 
-    /**
-     * These are date time ops put here to share the same evaluator factory.
-     */
-
-    @Evaluators.Base(DateEvaluator.class)
-    static Date min(@Nonnull Date value0, Date value1) {
-        return value0.compareTo(value1) < 0 ? value0 : value1;
-    }
-
+    // This is not arithmetic op, but put here to share the same evaluator factory.
     @Evaluators.Base(DateEvaluator.class)
     static Date max(@Nonnull Date value0, Date value1) {
         return value0.compareTo(value1) >= 0 ? value0 : value1;
     }
 
+    // This is not arithmetic op, but put here to share the same evaluator factory.
+    @Nonnull
     @Evaluators.Base(TimeEvaluator.class)
-    static Time min(@Nonnull Time value0, Time value1) {
-        return value0.compareTo(value1) < 0 ? value0 : value1;
-    }
-
-    @Evaluators.Base(TimeEvaluator.class)
-    static Time max(@Nonnull Time value0, Time value1) {
+    static Time max(@Nonnull Time value0, @Nonnull Time value1) {
+        if (log.isDebugEnabled()) {
+            log.debug(
+                "max({}, {}):Time called.",
+                Time2StringUtils.toGmtString(value0),
+                Time2StringUtils.toGmtString(value1)
+            );
+        }
         return value0.compareTo(value1) >= 0 ? value0 : value1;
     }
 
-    @Evaluators.Base(TimestampEvaluator.class)
-    static Timestamp min(@Nonnull Timestamp value0, Timestamp value1) {
-        return value0.compareTo(value1) < 0 ? value0 : value1;
-    }
-
+    // This is not arithmetic op, but put here to share the same evaluator factory.
     @Evaluators.Base(TimestampEvaluator.class)
     static Timestamp max(@Nonnull Timestamp value0, Timestamp value1) {
         return value0.compareTo(value1) >= 0 ? value0 : value1;

--- a/dingo-expr/runtime/src/main/java/io/dingodb/expr/runtime/evaluator/utils/Time2StringUtils.java
+++ b/dingo-expr/runtime/src/main/java/io/dingodb/expr/runtime/evaluator/utils/Time2StringUtils.java
@@ -16,14 +16,19 @@
 
 package io.dingodb.expr.runtime.evaluator.utils;
 
+import java.text.DateFormat;
+import java.text.SimpleDateFormat;
 import java.time.LocalDateTime;
 import java.time.format.DateTimeFormatter;
+import java.util.TimeZone;
+import javax.annotation.Nonnull;
 
 public final class Time2StringUtils {
 
     /**
      * convert input timestamp to string with timezone.
-     * @param input timestamp
+     *
+     * @param input  timestamp
      * @param format default "yyyy-MM-dd HH:mm:ss"
      * @return string after format.
      */
@@ -35,6 +40,7 @@ public final class Time2StringUtils {
 
     /**
      * convert input time to string with timezone.
+     *
      * @param input java.sql.Time
      * @return
      */
@@ -44,4 +50,10 @@ public final class Time2StringUtils {
         return result.toString();
     }
 
+    @Nonnull
+    public static String toGmtString(java.util.Date value) {
+        final DateFormat dtf = new SimpleDateFormat("yyyy-MM-dd HH:mm:ss.SSS");
+        dtf.setTimeZone(TimeZone.getTimeZone("UTC"));
+        return dtf.format(value);
+    }
 }


### PR DESCRIPTION
Lack of explainTerms, Calcite take the two DingoHash as the same so finally they share the same `keys`, which is completely wrong.

Add explainTerms to all DingoRels with private fields.
