### PR TITLE
[dingo-store-mpu, dingo-net-netty] Use RocksDB checkpoint to implement backup mechanism and fix a FileReceiver bug.

### DIFF
--- a/dingo-mirror-processing-unit/src/test/java/io/dingodb/mpu/test/RocksStorageTest.java
+++ b/dingo-mirror-processing-unit/src/test/java/io/dingodb/mpu/test/RocksStorageTest.java
@@ -1,0 +1,146 @@
+/*
+ * Copyright 2021 DataCanvas
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package io.dingodb.mpu.test;
+
+import io.dingodb.common.CommonId;
+import io.dingodb.common.Location;
+import io.dingodb.mpu.core.CoreMeta;
+import io.dingodb.mpu.storage.rocks.RocksStorage;
+import org.junit.jupiter.api.Assertions;
+import org.junit.jupiter.api.Test;
+import io.dingodb.common.util.FileUtils;
+
+import org.rocksdb.*;
+
+import java.io.File;
+import java.nio.file.Files;
+
+public class RocksStorageTest {
+    static {
+        RocksDB.loadLibrary();
+    }
+
+    public RocksStorage storage;
+
+    public void createRocksStorage() {
+        try {
+            // TODO generate useful parameters
+            byte type = 0;
+            CommonId id = CommonId.prefix(type);
+            CommonId coreId = CommonId.prefix(type);
+            CommonId mpuId = CommonId.prefix(type);
+            Location location = new Location("127.0.0.1", 8000);
+            int priority = 0;
+            CoreMeta coreMeta = new CoreMeta(id, coreId, mpuId, location, priority);
+            String test_db_path = String.format("/tmp/testRocksStorage-%d", System.nanoTime());
+
+            storage = new RocksStorage(coreMeta, test_db_path,
+                "", "", 0);
+
+            Assertions.assertNotNull(storage);
+        } catch (Exception e) {
+            throw new RuntimeException(e);
+        }
+    }
+
+    public void cleanupRocksStorage() {
+        try {
+            storage.destroy();
+            FileUtils.deleteIfExists(storage.path);
+        } catch (Exception e) {
+            throw new RuntimeException(e);
+        }
+    }
+
+    @Test
+    public void testCreateRocksStorage() {
+        Assertions.assertDoesNotThrow(() -> createRocksStorage());
+        Assertions.assertNotNull(storage);
+        Assertions.assertDoesNotThrow(() -> cleanupRocksStorage());
+    }
+
+    @Test
+    public void testCheckpoint() {
+        Assertions.assertDoesNotThrow(() -> createRocksStorage());
+        Assertions.assertNotNull(storage);
+
+        Assertions.assertDoesNotThrow(()->
+            {
+                // recreate db, don't use EventListener
+                // close and clean old db
+                storage.checkpoint.close();
+                storage.db.close();
+                storage.instruction.close();
+                FileUtils.deleteIfExists(storage.dbPath);
+                FileUtils.deleteIfExists(storage.instructionPath);
+
+                //create new db
+                Options options = new Options();
+                options.setCreateIfMissing(true);
+                options.setCompressionType(CompressionType.NO_COMPRESSION);
+
+                storage.db = RocksDB.open(options, storage.dbPath.toString());
+                storage.instruction = RocksDB.open(options, storage.instructionPath.toString());
+                storage.checkpoint = Checkpoint.create(storage.db);
+
+                //put test data into new db
+                String test_key = "test_key";
+                for (int i = 0; i < 1000; i++) {
+                    storage.db.put(String.format("test_key_%d", i).getBytes(), test_key.getBytes());
+                    storage.db.put(test_key.getBytes(), test_key.getBytes());
+                }
+
+                //create new checkpoint
+                storage.createNewCheckpoint();
+                storage.createNewCheckpoint();
+                storage.createNewCheckpoint();
+
+                File[] directories = new File(storage.checkpointPath.toString()).listFiles(File::isDirectory);
+                Assertions.assertEquals(directories.length, 3);
+
+                // test GetLatestCheckpointName
+                String latest_checkpoint_name = storage.GetLatestCheckpointName(storage.LOCAL_CHECKPOINT_PREFIX);
+                for (File checkpoint_dir : directories) {
+                    Assertions.assertTrue(checkpoint_dir.getName().compareTo(latest_checkpoint_name) <= 0);
+                }
+
+                // test purgeOldCheckpoint
+                storage.purgeOldCheckpoint(2);
+                directories = new File(storage.checkpointPath.toString()).listFiles(File::isDirectory);
+                Assertions.assertEquals(directories.length, 2);
+
+                // test restoreFromCheckpoint
+                storage.db.delete(test_key.getBytes());
+                byte[] value = storage.db.get(test_key.getBytes());
+                Assertions.assertNull(value);
+
+                // make a fake remote checkpoint
+                Files.move(
+                    storage.checkpointPath.resolve(latest_checkpoint_name),
+                    storage.path.resolve(
+                        String.format("%s%s", storage.REMOTE_CHECKPOINT_PREFIX, "checkpoint"
+                        )
+                    )
+                );
+                storage.applyBackup();
+                value = storage.db.get(test_key.getBytes());
+                Assertions.assertEquals(new String(value), test_key);
+            }
+        );
+        Assertions.assertDoesNotThrow(() -> cleanupRocksStorage());
+    }
+}

--- a/dingo-net-netty/src/main/java/io/dingodb/net/netty/service/FileReceiver.java
+++ b/dingo-net-netty/src/main/java/io/dingodb/net/netty/service/FileReceiver.java
@@ -40,7 +40,8 @@ public class FileReceiver implements Consumer<ByteBuffer> {
 
     private static final NetService netService = NetServiceProvider.NET_SERVICE_INSTANCE;
 
-    static {
+    // Note: This function is called in FileSender class's static code
+    public static void registerFileTransferMessageListener() {
         netService.registerTagMessageListener(
             FILE_TRANSFER,
             (msg, ch) -> {

--- a/dingo-net-netty/src/main/java/io/dingodb/net/netty/service/FileReceiver.java
+++ b/dingo-net-netty/src/main/java/io/dingodb/net/netty/service/FileReceiver.java
@@ -60,7 +60,8 @@ public class FileReceiver implements Consumer<ByteBuffer> {
     private final Channel channel;
 
     public FileReceiver(Path path, Channel channel) throws Exception {
-        log.info(String.format("FileReceiver::FileReceiver Path=[%s] Parent=[%s]", path.toString(), path.getParent().toString()));
+        log.info(String.format("FileReceiver::FileReceiver Path=[%s] Parent=[%s]",
+            path.toString(), path.getParent().toString()));
         Files.deleteIfExists(path);
         Files.createDirectories(path.getParent());
         this.fileChannel = FileChannel.open(path, StandardOpenOption.WRITE, StandardOpenOption.CREATE);

--- a/dingo-net-netty/src/main/java/io/dingodb/net/netty/service/FileReceiver.java
+++ b/dingo-net-netty/src/main/java/io/dingodb/net/netty/service/FileReceiver.java
@@ -21,6 +21,7 @@ import io.dingodb.net.Message;
 import io.dingodb.net.netty.Channel;
 import io.dingodb.net.netty.NetService;
 import io.dingodb.net.netty.NetServiceProvider;
+import lombok.extern.slf4j.Slf4j;
 
 import java.io.IOException;
 import java.nio.ByteBuffer;
@@ -34,6 +35,7 @@ import java.util.function.Consumer;
 import static io.dingodb.common.util.NoBreakFunctions.wrap;
 import static io.dingodb.net.Message.FILE_TRANSFER;
 
+@Slf4j
 public class FileReceiver implements Consumer<ByteBuffer> {
 
     private static final NetService netService = NetServiceProvider.NET_SERVICE_INSTANCE;
@@ -57,6 +59,7 @@ public class FileReceiver implements Consumer<ByteBuffer> {
     private final Channel channel;
 
     public FileReceiver(Path path, Channel channel) throws Exception {
+        log.info(String.format("FileReceiver::FileReceiver Path=[%s] Parent=[%s]", path.toString(), path.getParent().toString()));
         Files.deleteIfExists(path);
         Files.createDirectories(path.getParent());
         this.fileChannel = FileChannel.open(path, StandardOpenOption.WRITE, StandardOpenOption.CREATE);

--- a/dingo-net-netty/src/main/java/io/dingodb/net/netty/service/FileSender.java
+++ b/dingo-net-netty/src/main/java/io/dingodb/net/netty/service/FileSender.java
@@ -25,6 +25,7 @@ import io.dingodb.net.netty.Channel;
 import io.dingodb.net.netty.NetService;
 import io.dingodb.net.netty.NetServiceProvider;
 import io.netty.buffer.ByteBuf;
+import lombok.extern.slf4j.Slf4j;
 
 import java.io.File;
 import java.nio.channels.FileChannel;
@@ -38,6 +39,7 @@ import java.util.concurrent.CountDownLatch;
 import static io.dingodb.net.Message.FILE_TRANSFER;
 import static io.dingodb.net.netty.Constant.USER_DEFINE_T;
 
+@Slf4j
 @AutoService(io.dingodb.net.service.FileTransferService.class)
 public class FileSender implements io.dingodb.net.service.FileTransferService {
 
@@ -50,6 +52,7 @@ public class FileSender implements io.dingodb.net.service.FileTransferService {
 
     @Override
     public void transfer(Location location, Path source, Path target) {
+        log.info(String.format("FileSender::transfer Location=[%s] Path=from [%s] to [%s]", location.toString(), source.toString(), target.toString()));
         if (!Files.exists(source) ) {
             throw new IllegalArgumentException(source + " not found.");
         }
@@ -85,6 +88,7 @@ public class FileSender implements io.dingodb.net.service.FileTransferService {
     }
 
     private void recursion(Location location, Path source, Path target) {
+        log.info(String.format("FileSender::recursion Location=[%s] Path=from [%s] to [%s]", location.toString(), source.toString(), target.toString()));
         File[] files = source.toFile().listFiles();
         if (files == null || files.length == 0) {
             return;

--- a/dingo-net-netty/src/main/java/io/dingodb/net/netty/service/FileSender.java
+++ b/dingo-net-netty/src/main/java/io/dingodb/net/netty/service/FileSender.java
@@ -50,6 +50,11 @@ public class FileSender implements io.dingodb.net.service.FileTransferService {
     public FileSender() {
     }
 
+    // registerTagMessageListener for tag FILE_TRANSFER
+    static {
+       FileReceiver.registerFileTransferMessageListener();
+    }
+
     @Override
     public void transfer(Location location, Path source, Path target) {
         log.info(String.format("FileSender::transfer Location=[%s] Path=from [%s] to [%s]", location.toString(), source.toString(), target.toString()));

--- a/dingo-net-netty/src/main/java/io/dingodb/net/netty/service/FileSender.java
+++ b/dingo-net-netty/src/main/java/io/dingodb/net/netty/service/FileSender.java
@@ -52,12 +52,13 @@ public class FileSender implements io.dingodb.net.service.FileTransferService {
 
     // registerTagMessageListener for tag FILE_TRANSFER
     static {
-       FileReceiver.registerFileTransferMessageListener();
+        FileReceiver.registerFileTransferMessageListener();
     }
 
     @Override
     public void transfer(Location location, Path source, Path target) {
-        log.info(String.format("FileSender::transfer Location=[%s] Path=from [%s] to [%s]", location.toString(), source.toString(), target.toString()));
+        log.info(String.format("FileSender::transfer Location=[%s] Path=from [%s] to [%s]",
+            location.toString(), source.toString(), target.toString()));
         if (!Files.exists(source) ) {
             throw new IllegalArgumentException(source + " not found.");
         }
@@ -93,7 +94,8 @@ public class FileSender implements io.dingodb.net.service.FileTransferService {
     }
 
     private void recursion(Location location, Path source, Path target) {
-        log.info(String.format("FileSender::recursion Location=[%s] Path=from [%s] to [%s]", location.toString(), source.toString(), target.toString()));
+        log.info(String.format("FileSender::recursion Location=[%s] Path=from [%s] to [%s]",
+            location.toString(), source.toString(), target.toString()));
         File[] files = source.toFile().listFiles();
         if (files == null || files.length == 0) {
             return;


### PR DESCRIPTION
1. Add checkpoint code in RocksStorage , also add unit-tests for new checkpoint code.
2. Remove deprecated backup code.
3. Remove all backup calls in RocksDB event listener.
4. Fix FileReceiver bug, now call registerTagMessageListener in  FileSender.

Best wishes to dingo maintainers!

And Dingo is an amazing database project!!!
