### PR TITLE
[dingo-store-mpu] Remote deprecated RocksDB API call of setBlockCacheSize

### DIFF
--- a/dingo-mirror-processing-unit/src/main/java/io/dingodb/mpu/storage/rocks/RocksStorage.java
+++ b/dingo-mirror-processing-unit/src/main/java/io/dingodb/mpu/storage/rocks/RocksStorage.java
@@ -170,7 +170,10 @@ public class RocksStorage implements Storage {
         final ColumnFamilyOptions cfOption = new ColumnFamilyOptions();
         BlockBasedTableConfig tableConfig = new BlockBasedTableConfig();
         tableConfig.setBlockSize(128 * 1024);
-        tableConfig.setBlockCacheSize(200 / 4 * 1024 * 1024 * 1024L);
+
+        // remove deprecated API: tableConfig.setBlockCacheSize(200 / 4 * 1024 * 1024 * 1024L);
+        Cache blockCache = new LRUCache(200 / 4 * 1024 * 1024 * 1024L);
+        tableConfig.setBlockCache(blockCache);
         cfOption.setTableFormatConfig(tableConfig);
         cfOption.setArenaBlockSize(128 * 1024 * 1024);
         cfOption.setMinWriteBufferNumberToMerge(4);


### PR DESCRIPTION
[dingo-store-mpu] Remote deprecated RocksDB API call of setBlockCacheSize

Replace with new setBlockCache call.

Signed-off-by: Ketor <d.ketor@gmail.com>