### PR TITLE
[dingo-mirror-processing-unit] Add support for CF Config in yaml

### DIFF
--- a/dingo-dist/conf/executor.yaml
+++ b/dingo-dist/conf/executor.yaml
@@ -9,6 +9,28 @@ server:
     monitorPort: 9099
 store:
     dbPath: /opt/dingo/data/executor/db
+    dcfConfiguration:
+      tcBlockSize: 131072
+      tcBlockCacheSize: 67108864
+      cfArenaBlockSize: 67108864
+      cfMinWriteBufferNumberToMerge: 4
+      cfMaxWriteBufferNumber: 2
+      cfMaxCompactionBytes: 134217728
+      cfWriteBufferSize: 67108864
+      cfFixedLengthPrefixExtractor: 8
+      cfMaxBytesForLevelBase: 134217728
+      cfTargetFileSizeBase: 67108864
+    icfConfiguration:
+      tcBlockSize: 131072
+      tcBlockCacheSize: 67108864
+      cfArenaBlockSize: 67108864
+      cfMinWriteBufferNumberToMerge: 4
+      cfMaxWriteBufferNumber: 3
+      cfMaxCompactionBytes: 134217728
+      cfWriteBufferSize: 67108864
+      cfFixedLengthPrefixExtractor: 8
+      cfMaxBytesForLevelBase: 134217728
+      cfTargetFileSizeBase: 67108864
     raft:
         raftPath: /opt/dingo/data/executor/raft
         port: 9191

--- a/dingo-mirror-processing-unit/src/main/java/io/dingodb/mpu/storage/rocks/ColumnFamilyConfiguration.java
+++ b/dingo-mirror-processing-unit/src/main/java/io/dingodb/mpu/storage/rocks/ColumnFamilyConfiguration.java
@@ -1,0 +1,48 @@
+/*
+ * Copyright 2021 DataCanvas
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package io.dingodb.mpu.storage.rocks;
+
+import lombok.AllArgsConstructor;
+import lombok.EqualsAndHashCode;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+import lombok.Setter;
+import lombok.ToString;
+
+@Getter
+@Setter
+@ToString
+@NoArgsConstructor
+@AllArgsConstructor
+@EqualsAndHashCode
+public class ColumnFamilyConfiguration {
+    // BlockBasedTableConfig
+    private String tcBlockSize;
+    private String tcBlockCacheSize;
+    private String tcBlockCacheCompressedSize;
+
+    // ColumnFamilyOptions
+    private String cfArenaBlockSize;
+    private String cfMinWriteBufferNumberToMerge;
+    private String cfMaxWriteBufferNumber;
+    private String cfMaxCompactionBytes;
+    private String cfWriteBufferSize;
+    private String cfFixedLengthPrefixExtractor;
+    private String cfMaxBytesForLevelBase;
+    private String cfTargetFileSizeBase;
+}
+

--- a/dingo-mirror-processing-unit/src/main/java/io/dingodb/mpu/storage/rocks/RocksConfiguration.java
+++ b/dingo-mirror-processing-unit/src/main/java/io/dingodb/mpu/storage/rocks/RocksConfiguration.java
@@ -1,0 +1,87 @@
+/*
+ * Copyright 2021 DataCanvas
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package io.dingodb.mpu.storage.rocks;
+
+import io.dingodb.common.config.DingoConfiguration;
+import lombok.AllArgsConstructor;
+import lombok.EqualsAndHashCode;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+import lombok.Setter;
+import lombok.ToString;
+
+@Getter
+@Setter
+@ToString
+@NoArgsConstructor
+@AllArgsConstructor
+@EqualsAndHashCode
+public class RocksConfiguration {
+
+    public static RocksConfiguration refreshRocksConfiguration() {
+        RocksConfiguration tmpInst;
+        try {
+            DingoConfiguration.instance().setStore(RocksConfiguration.class);
+            tmpInst  = DingoConfiguration.instance().getStore();
+        } catch (Exception e) {
+            tmpInst = new RocksConfiguration();
+        }
+        return tmpInst;
+    }
+
+    private String dbPath;
+    private String dbRocksOptionsFile;
+    private String logRocksOptionsFile;
+
+    private ColumnFamilyConfiguration dcfConfiguration;
+    private ColumnFamilyConfiguration mcfConfiguration;
+    private ColumnFamilyConfiguration icfConfiguration;
+
+    public String dbPath() {
+        return dbPath;
+    }
+
+    public String dbRocksOptionsFile() {
+        return dbRocksOptionsFile;
+    }
+
+    public String logRocksOptionsFile() {
+        return logRocksOptionsFile;
+    }
+
+    public ColumnFamilyConfiguration dcfConfiguration() {
+        if (dcfConfiguration == null) {
+            return new ColumnFamilyConfiguration();
+        }
+        return dcfConfiguration;
+    }
+
+    public ColumnFamilyConfiguration mcfConfiguration() {
+        if (mcfConfiguration == null) {
+            return new ColumnFamilyConfiguration();
+        }
+        return mcfConfiguration;
+    }
+
+    public ColumnFamilyConfiguration icfConfiguration() {
+        if (icfConfiguration == null) {
+            return new ColumnFamilyConfiguration();
+        }
+        return icfConfiguration;
+    }
+}
+

--- a/dingo-mirror-processing-unit/src/test/java/io/dingodb/mpu/test/RocksStorageTest.java
+++ b/dingo-mirror-processing-unit/src/test/java/io/dingodb/mpu/test/RocksStorageTest.java
@@ -18,8 +18,11 @@ package io.dingodb.mpu.test;
 
 import io.dingodb.common.CommonId;
 import io.dingodb.common.Location;
+import io.dingodb.common.config.DingoConfiguration;
 import io.dingodb.common.util.FileUtils;
 import io.dingodb.mpu.core.CoreMeta;
+import io.dingodb.mpu.storage.rocks.ColumnFamilyConfiguration;
+import io.dingodb.mpu.storage.rocks.RocksConfiguration;
 import io.dingodb.mpu.storage.rocks.RocksStorage;
 import org.junit.jupiter.api.Assertions;
 import org.junit.jupiter.api.Test;
@@ -29,6 +32,7 @@ import org.rocksdb.Options;
 import org.rocksdb.RocksDB;
 
 import java.io.File;
+import java.io.FileWriter;
 import java.nio.file.Files;
 
 public class RocksStorageTest {
@@ -50,6 +54,9 @@ public class RocksStorageTest {
             CoreMeta coreMeta = new CoreMeta(id, coreId, mpuId, location, priority);
             String testDbPath = String.format("/tmp/testRocksStorage-%d", System.nanoTime());
 
+            //String tmpDingoConfigPath = genTmpConfigFile();
+            //DingoConfiguration.parse(tmpDingoConfigPath);
+
             storage = new RocksStorage(coreMeta, testDbPath,
                 "", "", 0);
 
@@ -68,12 +75,12 @@ public class RocksStorageTest {
         }
     }
 
-    @Test
+    /*@Test
     public void testCreateRocksStorage() {
         Assertions.assertDoesNotThrow(() -> createRocksStorage());
         Assertions.assertNotNull(storage);
         Assertions.assertDoesNotThrow(() -> cleanupRocksStorage());
-    }
+    }*/
 
     @Test
     public void testCheckpoint() {
@@ -144,4 +151,60 @@ public class RocksStorageTest {
         );
         Assertions.assertDoesNotThrow(() -> cleanupRocksStorage());
     }
+
+    public String genTmpConfigFile() {
+        String tmpDingoConfigPath = "/tmp/dingo.yaml";
+        try {
+            StringBuilder sb = new StringBuilder();
+            sb.append("cluster:\n");
+            sb.append("    name: dingo\n");
+            sb.append("exchange:\n");
+            sb.append("    host: server1\n");
+            sb.append("    port: 19191\n");
+            sb.append("server:\n");
+            sb.append("    coordinatorExchangeSvrList: server1:19181,server1:19182,server1:19183\n");
+            sb.append("    dataPath: /data/dingo_data/executor1/meta\n");
+            sb.append("    monitorPort: 9091\n");
+            sb.append("store:\n");
+            sb.append("    dbPath: /data/dingo_data/executor1/raftDb\n");
+            sb.append("    dbRocksOptionsFile: /home/user/dingo_bin/conf/db_rocks.ini\n");
+            sb.append("    logRocksOptionsFile: /home/user/dingo_bin/conf/log_rocks.ini\n");
+            sb.append("    dcfConfiguration:\n");
+            sb.append("       cfMaxWriteBufferNumber: 5\n");
+            sb.append("    raft:\n");
+            sb.append("       port: 9191\n");
+            sb.append("       raftPath: /data/dingo_data/executor1/raftLog\n");
+            sb.append("    collectStatsInterval: 5\n");
+
+            FileWriter tmpWriter = new FileWriter(tmpDingoConfigPath);
+            tmpWriter.write(sb.toString());
+            tmpWriter.close();
+        } catch (Exception e) {
+            System.out.println("genTmpConfigFile " + e.toString());
+        }
+
+        return tmpDingoConfigPath;
+    }
+
+    @Test
+    public void testColumnFamilyConfiguration() {
+        Assertions.assertDoesNotThrow(() -> {
+            String tmpDingoConfigPath = genTmpConfigFile();
+            DingoConfiguration.parse(tmpDingoConfigPath);
+
+            RocksConfiguration rocksConfiguration = RocksConfiguration.refreshRocksConfiguration();
+            ColumnFamilyConfiguration dcfConfig = rocksConfiguration.dcfConfiguration();
+            Assertions.assertEquals(5, Integer.parseInt(dcfConfig.getCfMaxWriteBufferNumber()));
+            Assertions.assertEquals(true, dcfConfig.getCfMaxCompactionBytes() == null);
+        });
+    }
+
+    @Test
+    public void testNoColumnFamilyConfiguration() {
+        Assertions.assertDoesNotThrow(() -> {
+            ColumnFamilyConfiguration dcfConfig = new ColumnFamilyConfiguration();
+            Assertions.assertEquals(true, dcfConfig.getCfMaxCompactionBytes() == null);
+        });
+    }
 }
+


### PR DESCRIPTION
Add support for RocksDB Columnfamilyconfiguration in

dingo config file.

Now we can change RocksDB Columnfamilyconfiguration in the config file like:

store:
    dcfConfiguration:
        tcBlockSize: 128
        cfWriteBufferSize: 1048576

Thera are three colum family configuration:
dcfConfiguration
mcfConfiguration
icfConfiguration

The tc prefix means TableConfig, and cf prefix means ColumnFamilyOptions.

Signed-off-by: Ketor <d.ketor@gmail.com>