### PR TITLE
[dingo-mirror-processing-unit] Fix RocksStorage destory bug and add bypass write option for RocksDB.

### DIFF
--- a/dingo-mirror-processing-unit/src/main/java/io/dingodb/mpu/storage/rocks/RocksConfiguration.java
+++ b/dingo-mirror-processing-unit/src/main/java/io/dingodb/mpu/storage/rocks/RocksConfiguration.java
@@ -46,6 +46,8 @@ public class RocksConfiguration {
     private String dbPath;
     private String dbRocksOptionsFile;
     private String logRocksOptionsFile;
+    private String bypassSaveInstruction;
+    private String bypassWriteDb;
 
     private ColumnFamilyConfiguration dcfConfiguration;
     private ColumnFamilyConfiguration mcfConfiguration;
@@ -82,6 +84,22 @@ public class RocksConfiguration {
             return new ColumnFamilyConfiguration();
         }
         return icfConfiguration;
+    }
+
+    public boolean bypassSaveInstruction() {
+        if (bypassSaveInstruction == null) {
+            return false;
+        } else {
+            return bypassSaveInstruction.equalsIgnoreCase("ABSOLUTELY_YES");
+        }
+    }
+
+    public boolean bypassWriteDb() {
+        if (bypassWriteDb == null) {
+            return false;
+        } else {
+            return bypassWriteDb.equalsIgnoreCase("ABSOLUTELY_YES");
+        }
     }
 }
 

--- a/dingo-store-mpu/src/main/java/io/dingodb/store/mpu/StoreInstance.java
+++ b/dingo-store-mpu/src/main/java/io/dingodb/store/mpu/StoreInstance.java
@@ -26,6 +26,7 @@ import io.dingodb.common.store.KeyValue;
 import io.dingodb.common.store.Part;
 import io.dingodb.common.table.TableDefinition;
 import io.dingodb.common.util.ByteArrayUtils;
+import io.dingodb.common.util.FileUtils;
 import io.dingodb.common.util.Optional;
 import io.dingodb.common.util.UdfUtils;
 import io.dingodb.common.util.Utils;
@@ -121,10 +122,8 @@ public class StoreInstance implements io.dingodb.store.api.StoreInstance {
         startKeyPartMap.clear();
         parts.values().forEach(Core::destroy);
         parts.clear();
-        /**
-         * to avoid file handle leak, when drop table
-         */
-        // FileUtils.deleteIfExists(path);
+        // After all parts destroyed, remove the table directory.
+        FileUtils.deleteIfExists(path);
     }
 
     public ApproximateStats approximateStats(Core core) {


### PR DESCRIPTION
Add bypass write option for RocksDB and fix RocksStorage.destory() bug.

With the new bypass options, we can perform raft latency test very easily, and also maybe disable instruction in some scenarios.

These two options can be setup like:

store:
    dbPath: /data2/dingo/data/executor1/db
    bypassSaveInstruction: ABSOLUTELY_YES
    bypassWriteDb: ABSOLUTELY_YES


The bypass option is true only when the option value is fully equal ignore case with "ABSOLUTELY_YES".

Also I fix the RocksStorage.destory bug by the way, my tmux session file is always deleted after a fully gradlew build.


Signed-off-by: Ketor <d.ketor@gmail.com>