### PR TITLE
[dingo-server-coordinator] Fix drop table cause the column query for the

### DIFF
--- a/dingo-server/coordinator/src/main/java/io/dingodb/server/coordinator/meta/adaptor/impl/TableAdaptor.java
+++ b/dingo-server/coordinator/src/main/java/io/dingodb/server/coordinator/meta/adaptor/impl/TableAdaptor.java
@@ -254,7 +254,7 @@ public class TableAdaptor extends BaseAdaptor<Table> {
             .flatMap(partId -> replicaAdaptor.getByDomain(partId.seq()).stream())
             .map(Replica::getId)
             .forEach(replicaAdaptor::delete);
-        columnAdaptor.deleteByDomain(id.domain());
+        columnAdaptor.deleteByDomain(id.seq());
         ClusterScheduler.instance().getTableScheduler(id).deleteTable();
         ClusterScheduler.instance().deleteTableScheduler(id);
     }


### PR DESCRIPTION
Fix drop table cause the column query for the first table return null.

This bug only affect online cache of coordinator, there is no data loss.

Signed-off-by: Ketor <d.ketor@gmail.com>