### PR TITLE
[dingo-index] remove index reboot from create table

### DIFF
--- a/dingo-server/executor/src/main/java/io/dingodb/server/executor/sidebar/TableSidebar.java
+++ b/dingo-server/executor/src/main/java/io/dingodb/server/executor/sidebar/TableSidebar.java
@@ -375,14 +375,19 @@ public class TableSidebar extends BaseSidebar implements io.dingodb.store.api.St
 
     @Override
     public void primary(long clock) {
+        boolean isCreate = false;
         if (view(KVInstructions.id, KVInstructions.GET_OC, tableId.encode()) == null) {
             initTable();
+            isCreate = true;
         }
-        definition = ProtostuffCodec.read((byte[]) view(KVInstructions.id, KVInstructions.GET_OC, tableId.encode()));
         setStarting();
         startParts();
         startIndexes();
-        storeInstance.reboot();
+        if (!isCreate) {
+            definition = ProtostuffCodec
+                .read((byte[]) view(KVInstructions.id, KVInstructions.GET_OC, tableId.encode()));
+            storeInstance.reboot();
+        }
         setRunning();
         super.primary(clock);
     }


### PR DESCRIPTION
createTable: 9000ms -> 5000ms

TableSidebar Create: 1200ms
selectPrimary: 1000ms
startParts : 2300ms
startIndex: 0ms (depends on index count, 0 = 0ms)
others: 500ms

sql -> sdk: 500ms