### PR TITLE
[dingo-calcite, dingo-driver] 1. create index exception handing 2. create index operator based privilege:index

### DIFF
--- a/dingo-calcite/src/main/codegen/includes/parserImpls.ftl
+++ b/dingo-calcite/src/main/codegen/includes/parserImpls.ftl
@@ -665,7 +665,7 @@ SqlGrant SqlGrant() : {
    <GRANT> { s = span(); }
    [ <ALL> <PRIVILEGES> { isAllPrivileges = true; } ]
    [
-     privilege = privilege() { privilegeList.add(privilege); }
+     privilege = privilege() { privilegeList.add(privilege.toLowerCase()); }
      (
        <COMMA> privilege = privilege() { privilegeList.add(privilege.toLowerCase()); }
      )*

--- a/dingo-calcite/src/main/java/io/dingodb/calcite/DingoDdlExecutor.java
+++ b/dingo-calcite/src/main/java/io/dingodb/calcite/DingoDdlExecutor.java
@@ -423,7 +423,7 @@ public class DingoDdlExecutor extends DdlExecutorImpl {
         UserDefinition userDefinition = UserDefinition.builder().user(sqlDropUser.name)
             .host(getRealAddress(sqlDropUser.host)).build();
         if (!userService.existsUser(userDefinition)) {
-            throw new RuntimeException("user is not exists");
+            throw new RuntimeException("user does not exist");
         }
         userService.dropUser(userDefinition);
     }
@@ -617,15 +617,15 @@ public class DingoDdlExecutor extends DdlExecutorImpl {
 
     public void validateDropIndex(MutableSchema schema, String tableName, String indexName) {
         if (schema.getTable(tableName) == null) {
-            throw new IllegalArgumentException("table " + tableName + " is not exists ");
+            throw new IllegalArgumentException("table " + tableName + " does not exist ");
         }
         TableDefinition tableDefinition = schema.getMetaService().getTableDefinition(tableName);
         if (tableDefinition != null) {
             if (tableDefinition.getIndexes() == null) {
-                throw new IllegalArgumentException("index " + indexName + " is not exists ");
+                throw new IllegalArgumentException("index " + indexName + " does not exist ");
             } else {
                 if (!tableDefinition.getIndexes().containsKey(indexName)) {
-                    throw new IllegalArgumentException("index " + indexName + " is not exists ");
+                    throw new IllegalArgumentException("index " + indexName + " does not exist ");
                 }
             }
 
@@ -634,7 +634,7 @@ public class DingoDdlExecutor extends DdlExecutorImpl {
 
     public void validateIndex(MutableSchema schema, String tableName, Index newIndex) {
         if (schema.getTable(tableName) == null) {
-            throw new IllegalArgumentException("table " + tableName + " is not exists ");
+            throw new IllegalArgumentException("table " + tableName + " does not exist ");
         }
         TableDefinition tableDefinition = schema.getMetaService().getTableDefinition(tableName);
         if (tableDefinition != null) {

--- a/dingo-calcite/src/main/java/io/dingodb/calcite/grammar/ddl/SqlAlterAddIndex.java
+++ b/dingo-calcite/src/main/java/io/dingodb/calcite/grammar/ddl/SqlAlterAddIndex.java
@@ -46,7 +46,9 @@ public class SqlAlterAddIndex extends SqlAlterTable {
     }
 
     public String[] getColumnNames() {
-        String[] columnNames = columns.stream().map(column -> column.getSimple()).toArray(String[]::new);
+        String[] columnNames = columns.stream().map(column -> column.getSimple())
+            .map(String::toUpperCase)
+            .toArray(String[]::new);
         return columnNames;
     }
 }

--- a/dingo-cli/src/main/java/io/dingodb/cli/source/Import.java
+++ b/dingo-cli/src/main/java/io/dingodb/cli/source/Import.java
@@ -70,10 +70,10 @@ public class Import {
     @Parameter(names = "--offset-reset", description = "Auto offset reset, Default [latest], optional [earliest]")
     private String offsetReset;
 
-    @Parameter(names = "--user", description = "dingo client login user")
+    @Parameter(names = "--user", description = "dingo client login user", required = true)
     private String user;
 
-    @Parameter(names = "--password", description = "dingo client login password")
+    @Parameter(names = "--password", description = "dingo client login password", required = true)
     private String password;
 
     public static void main(String[] args) throws Exception {

--- a/dingo-driver/client/src/main/java/io/dingodb/driver/auth/service/IdentityAuthImpl.java
+++ b/dingo-driver/client/src/main/java/io/dingodb/driver/auth/service/IdentityAuthImpl.java
@@ -65,8 +65,8 @@ public class IdentityAuthImpl implements IdentityAuth {
     public void cachePrivileges(Authentication authentication) {
         String user = authentication.getUsername();
         String host = authentication.getHost();
-        if (!env.getPrivilegeGatherMap().containsKey(authentication.getNormalUser())) {
-            if (!env.getPrivilegeGatherMap().containsKey(authentication.getUser())) {
+        if (!env.getPrivilegeGatherMap().containsKey(authentication.getUser())) {
+            if (!env.getPrivilegeGatherMap().containsKey(authentication.getNormalUser())) {
                 PrivilegeGather privilegeGather = userService.getPrivilegeDef(null, user, host);
                 env.getPrivilegeGatherMap().put(privilegeGather.key(),
                     privilegeGather);

--- a/dingo-driver/host/src/main/java/io/dingodb/driver/DingoMeta.java
+++ b/dingo-driver/host/src/main/java/io/dingodb/driver/DingoMeta.java
@@ -625,7 +625,10 @@ public class DingoMeta extends MetaImpl {
         List indexScanList = new ArrayList();
         if (schemaName != null) {
             final CalciteSchema calciteSchema = rootSchema.getSubSchema(schemaName, false);
-            MutableSchema schema = (MutableSchema) calciteSchema.schema;
+            if (calciteSchema == null) {
+                throw ExceptionUtils.toRuntime(new IllegalArgumentException("schema does not exist"));
+            }
+            MutableSchema schema  = (MutableSchema) calciteSchema.schema;
             if (schema != null && schema.getTable(tableName) != null) {
                 Collection<Index> indices = schema.getIndex(tableName);
 
@@ -641,6 +644,8 @@ public class DingoMeta extends MetaImpl {
                     }
                     return Arrays.stream(indexScans);
                 }).collect(Collectors.toList());
+            } else {
+                throw ExceptionUtils.toRuntime(new IllegalArgumentException("table does not exist"));
             }
         }
 

--- a/dingo-server/client/src/main/java/io/dingodb/server/client/meta/service/MetaServiceClient.java
+++ b/dingo-server/client/src/main/java/io/dingodb/server/client/meta/service/MetaServiceClient.java
@@ -171,6 +171,7 @@ public class MetaServiceClient implements MetaService {
             .ifPresent(tableDefinitionCache::remove)
             .map(this::partitionServices)
             .ifPresent(__ -> __.forEach(pid -> Optional.ifPresent(serviceCache.remove(pid), ServiceConnector::close)));
+        tableIdCache.remove(name);
     }
 
     private Set<CommonId> partitionServices(CommonId tableId) {

--- a/dingo-server/executor/src/main/java/io/dingodb/server/executor/api/TableApi.java
+++ b/dingo-server/executor/src/main/java/io/dingodb/server/executor/api/TableApi.java
@@ -77,8 +77,9 @@ public class TableApi implements io.dingodb.server.api.TableApi {
 
     @Override
     public CommonId createIndex(CommonId id, Index index) {
+        TableDefinition tableDefinition = null;
         try {
-            TableDefinition tableDefinition = getDefinition(id);
+            tableDefinition = getDefinition(id);
             index.setStatus(IndexStatus.BUSY);
             tableDefinition.addIndex(index);
             tableDefinition.increaseVersion();
@@ -112,6 +113,9 @@ public class TableApi implements io.dingodb.server.api.TableApi {
             tableSidebar.setRunning();
             return metaIndex.getId();
         } catch (Exception e) {
+            if (tableDefinition != null) {
+               tableDefinition.removeIndex(index.getName());
+            }
             throw new RuntimeException(e);
         }
     }


### PR DESCRIPTION
1. bug: 重启executor时，未选主成功创建表失败，但是创建索引成功 改为如果判断创建表失败，同步删除索引
2. 索引bug: create index / drop index 依赖于index权限 alter table add index: 依赖alter和index权限 ； create table( index..) 依赖于create,index权限
3.  删除表时同步删除driver端缓存 tableIdCache里内容
4.  查看不存在表索引时弹出错误
5. create index 关联表列名大小写问题
6. 登录成功缓存用户信息优先级调整： user @ % -> user @ host  改为 user @ host -> user@ %,  匹配用户时优先匹配具体ip的用户