### PR TITLE
[dingo-server] fix bug: drop index without cache

### DIFF
--- a/dingo-server/client/src/main/java/io/dingodb/server/client/meta/service/MetaServiceClient.java
+++ b/dingo-server/client/src/main/java/io/dingodb/server/client/meta/service/MetaServiceClient.java
@@ -117,7 +117,6 @@ public class MetaServiceClient implements MetaService {
             log.error("Can not load [{}] meta service.", id, e);
             return;
         }
-
         api.getTableMetas(id).forEach(this::addTableCache);
         api.getSubSchemas(id).forEach(this::addSubMetaServiceCache);
     }
@@ -355,6 +354,8 @@ public class MetaServiceClient implements MetaService {
         CommonId tableId = getTableId(tableName);
         TableApi tableApi = ApiRegistry.getDefault().proxy(TableApi.class, getTableConnector(tableId));
         tableApi.deleteIndex(tableId, indexName);
+        TableDefinition tableDefinition = tableDefinitionCache.get(tableId);
+        tableDefinition.removeIndex(indexName);
     }
 
     @Override


### PR DESCRIPTION
1. 删除索引时同步删除driver端缓存TableDefinition索引数据