### PR TITLE
Use latest version of JavaCC gradle plugin

### DIFF
--- a/dingo-calcite/build.gradle
+++ b/dingo-calcite/build.gradle
@@ -14,21 +14,10 @@
  * limitations under the License.
  */
 
-buildscript {
-    repositories {
-        maven {
-            url "https://plugins.gradle.org/m2/"
-        }
-    }
-    dependencies {
-        classpath "ca.coglinc:javacc-gradle-plugin:2.4.0"
-    }
-}
-
 plugins {
     id 'java-conventions'
     id 'java-library'
-    id "ca.coglinc.javacc" version "2.4.0"
+    id "org.javacc.javacc" version "3.0.0"
 }
 
 configurations {
@@ -55,8 +44,6 @@ dependencies {
     fmppTask "com.googlecode.fmpp-maven-plugin:fmpp-maven-plugin:1.0"
     fmppTask "org.freemarker:freemarker:2.3.31"
 }
-
-apply plugin: "ca.coglinc.javacc"
 
 sourceSets {
     main {


### PR DESCRIPTION
New version of the JavaCC plugin is out: [release notes](https://github.com/javacc/javaccPlugin/releases/tag/javacc-gradle-plugin-3.0.0). Because the plugin ID changed, it won't be found by usual dependency update mechanisms, so I'm making  PRs manually to update the major projects on GitHub that are using an older version of the plugin.

The new version should make compilation of `dingo-calcite` a bit faster and improve compatibility with future releases of Gradle.

I locally checked that `dingo-calcite:test` is successful with this change, but have not done any other testing.