### PR TITLE
[fix][mysql-service] Mysql client show type array null error

### DIFF
--- a/dingo-driver/mysql-service/src/main/java/io/dingodb/driver/mysql/command/MysqlResponseHandler.java
+++ b/dingo-driver/mysql-service/src/main/java/io/dingodb/driver/mysql/command/MysqlResponseHandler.java
@@ -180,8 +180,10 @@ public class MysqlResponseHandler {
             DingoArray dingoArray = (DingoArray) val;
             arrayVal = (List<Object>) dingoArray.getArray();
         }
-        val = StringUtils.join(arrayVal);
-        return val;
+        if (arrayVal == null) {
+            return "null";
+        }
+        return StringUtils.join(arrayVal);
     }
 
     private static void handlerPrepareRowPacket(ResultSet resultSet,


### PR DESCRIPTION
mysql客户端array类型为null显示为空