### PR TITLE
[wip][fix][mysql-service] Resolve Chinese garbled code

### DIFF
--- a/dingo-calcite/src/main/java/io/dingodb/calcite/runtime/DingoResource.java
+++ b/dingo-calcite/src/main/java/io/dingodb/calcite/runtime/DingoResource.java
@@ -73,6 +73,9 @@ public interface DingoResource {
     @BaseMessage("Access denied for user ''{0}''@''{1}'' to database ''{2}''")
     ExInst<DingoSqlException> accessDeniedToDb(String a0, String a1, String a2);
 
+    @BaseMessage("Unknown character set ''{0}''")
+    ExInst<DingoSqlException> unknownCharacterSet(String a0);
+
     @BaseMessage("Error 1051(42S02): Unknown table ''{0}''")
     ExInst<DingoSqlException> unknownTable(String a0);
 }

--- a/dingo-calcite/src/main/java/io/dingodb/calcite/type/DingoSqlTypeFactory.java
+++ b/dingo-calcite/src/main/java/io/dingodb/calcite/type/DingoSqlTypeFactory.java
@@ -23,6 +23,8 @@ import org.apache.calcite.sql.type.BasicSqlType;
 import org.apache.calcite.sql.type.SqlTypeName;
 
 import java.lang.reflect.Type;
+import java.nio.charset.Charset;
+import java.nio.charset.StandardCharsets;
 import java.sql.Date;
 import java.sql.Time;
 import java.sql.Timestamp;
@@ -98,5 +100,10 @@ public class DingoSqlTypeFactory extends JavaTypeFactoryImpl {
         }
         // This will copy any multiset type as `MultisetSqlType`.
         return super.createTypeWithNullability(type, nullable);
+    }
+
+    @Override
+    public Charset getDefaultCharset() {
+        return StandardCharsets.UTF_8;
     }
 }

--- a/dingo-calcite/src/test/java/io/dingodb/calcite/TestInsert.java
+++ b/dingo-calcite/src/test/java/io/dingodb/calcite/TestInsert.java
@@ -49,10 +49,10 @@ import org.junit.jupiter.params.ParameterizedTest;
 import org.junit.jupiter.params.provider.ValueSource;
 
 import java.math.BigDecimal;
+import java.nio.charset.StandardCharsets;
 import java.sql.Date;
 import java.util.List;
 
-import static org.apache.calcite.config.CalciteSystemProperty.DEFAULT_CHARSET;
 import static org.assertj.core.api.Assertions.assertThat;
 import static org.junit.jupiter.api.Assertions.assertThrows;
 
@@ -94,7 +94,7 @@ public class TestInsert {
         assertThat(tuple).element(1)
             .hasFieldOrPropertyWithValue("value", new NlsString(
                 "Alice",
-                DEFAULT_CHARSET.value(),
+                StandardCharsets.UTF_8.name(),
                 new SqlCollation(SqlCollation.Coercibility.IMPLICIT)
             ));
         assertThat(tuple).element(2)

--- a/dingo-common/src/main/java/io/dingodb/common/mysql/scope/ScopeVariables.java
+++ b/dingo-common/src/main/java/io/dingodb/common/mysql/scope/ScopeVariables.java
@@ -26,7 +26,9 @@ public class ScopeVariables {
 
     public static Properties sessionVariables = new Properties();
 
-    public static List<String> immutableVariables = new ArrayList<>();
+    public static final List<String> immutableVariables = new ArrayList<>();
+
+    public static final List<String> characterSet = new ArrayList<>();
 
     static {
         // used to client connection
@@ -42,5 +44,11 @@ public class ScopeVariables {
         immutableVariables.add("have_openssl");
         immutableVariables.add("have_ssl");
         immutableVariables.add("have_statement_timeout");
+
+        characterSet.add("utf8mb4");
+        characterSet.add("utf8");
+        characterSet.add("utf-8");
+        characterSet.add("gbk");
+        characterSet.add("latin1");
     }
 }

--- a/dingo-common/src/main/java/io/dingodb/common/util/Utils.java
+++ b/dingo-common/src/main/java/io/dingodb/common/util/Utils.java
@@ -161,5 +161,12 @@ public final class Utils {
         }).collect(Collectors.toList());
     }
 
+    public static String getCharacterSet(String characterSet) {
+        if (characterSet.equalsIgnoreCase("utf8mb4")) {
+            return "utf8";
+        }
+        return characterSet;
+    }
+
     public static final int INTEGER_LEN_IN_BYTES = 4;
 }

--- a/dingo-driver/host/src/main/resources/io/dingodb/calcite/runtime/DingoResource_en.properties
+++ b/dingo-driver/host/src/main/resources/io/dingodb/calcite/runtime/DingoResource_en.properties
@@ -26,6 +26,7 @@ NoMatchingRowForUser=Error 1133 (42000): Can't find any matching row in the user
 AccessDeniedToUser=Error 1045(28000): Access denied for user ''{0}''@''{1}''
 AccessDeniedToDb=Error 1044(42000): Access denied for user ''{0}''@''{1}'' to database ''{2}''
 UnknownTable=Error 1051(42S02): Unknown table ''{0}''
+UnknownCharacterSet=Error 1115(42000): Unknown character set ''{0}''
 
 # Other errors
 PrimaryKeyRequired=Error 1001 (45000): Primary keys are required in table ''{0}''

--- a/dingo-driver/mysql-service/src/main/java/io/dingodb/driver/mysql/command/MysqlResponseHandler.java
+++ b/dingo-driver/mysql-service/src/main/java/io/dingodb/driver/mysql/command/MysqlResponseHandler.java
@@ -49,6 +49,8 @@ import java.util.TimeZone;
 import java.util.concurrent.atomic.AtomicLong;
 import java.util.stream.Collectors;
 
+import static io.dingodb.calcite.operation.SetOptionOperation.CONNECTION_CHARSET;
+import static io.dingodb.common.util.Utils.getCharacterSet;
 import static io.dingodb.common.util.Utils.getDateByTimezone;
 
 @Slf4j
@@ -138,6 +140,9 @@ public class MysqlResponseHandler {
         while (resultSet.next()) {
             ResultSetRowPacket resultSetRowPacket = new ResultSetRowPacket();
             resultSetRowPacket.packetId = (byte) packetId.getAndIncrement();
+            String characterSet = mysqlConnection.getConnection().getClientInfo(CONNECTION_CHARSET);
+            characterSet = getCharacterSet(characterSet);
+            resultSetRowPacket.setCharacterSet(characterSet);
             for (int i = 1; i <= columnCount; i ++) {
                 Object val = resultSet.getObject(i);
                 typeName = metaData.getColumnTypeName(i);
@@ -193,6 +198,9 @@ public class MysqlResponseHandler {
                                                 int columnCount) throws SQLException {
         while (resultSet.next()) {
             PrepareResultSetRowPacket resultSetRowPacket = new PrepareResultSetRowPacket();
+            String characterSet = mysqlConnection.getConnection().getClientInfo(CONNECTION_CHARSET);
+            characterSet = getCharacterSet(characterSet);
+            resultSetRowPacket.setCharacterSet(characterSet);
             resultSetRowPacket.packetId = (byte) packetId.getAndIncrement();
             resultSetRowPacket.setMetaData(resultSet.getMetaData());
             for (int i = 1; i <= columnCount; i ++) {

--- a/dingo-driver/mysql-service/src/main/java/io/dingodb/driver/mysql/packet/PrepareResultSetRowPacket.java
+++ b/dingo-driver/mysql-service/src/main/java/io/dingodb/driver/mysql/packet/PrepareResultSetRowPacket.java
@@ -16,16 +16,13 @@
 
 package io.dingodb.driver.mysql.packet;
 
-import io.dingodb.common.mysql.DingoArray;
 import io.dingodb.driver.mysql.MysqlConnection;
 import io.dingodb.driver.mysql.util.BufferUtil;
 import io.netty.buffer.ByteBuf;
 import lombok.Setter;
-import org.apache.calcite.avatica.util.ArrayImpl;
-import org.apache.commons.lang3.StringUtils;
 
+import java.io.UnsupportedEncodingException;
 import java.sql.Array;
-import java.sql.Connection;
 import java.sql.Date;
 import java.sql.ResultSetMetaData;
 import java.sql.SQLException;
@@ -38,6 +35,9 @@ import static io.dingodb.driver.mysql.command.MysqlResponseHandler.getArrayObjec
 
 public class PrepareResultSetRowPacket extends MysqlPacket {
     List<Object> values = new ArrayList<>();
+
+    @Setter
+    private String characterSet;
 
     @Setter
     private ResultSetMetaData metaData;
@@ -85,7 +85,12 @@ public class PrepareResultSetRowPacket extends MysqlPacket {
                     case "ARRAY":
                     case "MULTISET":
                         if (val != null) {
-                            byte[] v = val.toString().getBytes();
+                            byte[] v = new byte[0];
+                            try {
+                                v = val.toString().getBytes(characterSet);
+                            } catch (UnsupportedEncodingException e) {
+                                throw new RuntimeException(e);
+                            }
                             values.set(i - 1, v);
                             totalSize += BufferUtil.getLength(v);
                         }

--- a/dingo-mysql-init/src/main/java/io/dingodb/mysql/MysqlInit.java
+++ b/dingo-mysql-init/src/main/java/io/dingodb/mysql/MysqlInit.java
@@ -239,11 +239,12 @@ public final class MysqlInit {
         values.add(new Object[]{"version_compile_machine", "x86_64"});
         values.add(new Object[]{"init_connect", ""});
         values.add(new Object[]{"collation_connection", "utf8_general_ci"});
-        values.add(new Object[]{"collation_server", "latin1_swedish_ci"});
-        values.add(new Object[]{"character_set_server", "latin1"});
-        values.add(new Object[]{"character_set_results", "utf8"});
-        values.add(new Object[]{"character_set_client", "utf8"});
-        values.add(new Object[]{"character_set_connection", "utf8"});
+        values.add(new Object[]{"collation_database", "utf8_general_ci"});
+        values.add(new Object[]{"collation_server", "utf8_general_ci"});
+        values.add(new Object[]{"character_set_server", "utf8"});
+        values.add(new Object[]{"character_set_results", "gbk"});
+        values.add(new Object[]{"character_set_client", "gbk"});
+        values.add(new Object[]{"character_set_connection", "gbk"});
         values.add(new Object[]{"auto_increment_increment", "1"});
         values.add(new Object[]{"auto_increment_offset", "1"});
         values.add(new Object[]{"protocol_version", "10"});

--- a/dingo-test/src/test/java/io/dingodb/test/QueryMetaDataTest.java
+++ b/dingo-test/src/test/java/io/dingodb/test/QueryMetaDataTest.java
@@ -147,7 +147,7 @@ public class QueryMetaDataTest {
                     },
                     new Object[]{
                         null, SCHEMA_NAME, "TEST", "NAME", 12,
-                        "VARCHAR(32) NOT NULL", 32, null, 10, 0,
+                        "VARCHAR(32) CHARACTER SET \"UTF-8\" NOT NULL", 32, null, 10, 0,
                         32, 2, "NO", "", ""
                     },
                     new Object[]{
@@ -174,7 +174,7 @@ public class QueryMetaDataTest {
                 .isRecords(Collections.singletonList(
                     new Object[]{
                         null, SCHEMA_NAME, "TEST", "NAME", 12,
-                        "VARCHAR(32) NOT NULL", 32, null, 10, 0,
+                        "VARCHAR(32) CHARACTER SET \"UTF-8\" NOT NULL", 32, null, 10, 0,
                         32, 2, "NO", "", ""
                     }
                 ));


### PR DESCRIPTION
1. mysql shell 默认为gbk编码， 所以character_set_connection， character_set_results, character_set_client默认设置为gbk，要不然会乱码
2. mysql jdbc 连接时会设置set names utf8mb4 ,会修改上面三个会话变量的值为utf-8,这样返回给mysql jdbc的是utf-8
3. mysql jdbc使用时需要String s = new String("中文".getBytes(), "utf8"); 才不乱码，其他乱码
4. mysql jdbc使用时可以在连接串添加characterEncoding=utf8 函数