### PR TITLE
[fix][dingo-calcite] Vector search sub query block

### DIFF
--- a/dingo-calcite/src/main/java/io/dingodb/calcite/rule/DingoVectorJoinRule.java
+++ b/dingo-calcite/src/main/java/io/dingodb/calcite/rule/DingoVectorJoinRule.java
@@ -66,7 +66,7 @@ public class DingoVectorJoinRule extends RelRule<DingoVectorJoinRule.Config>  {
                 RexLiteral rexLiteral = rexBuilder.makeLiteral("1");
                 RexLiteral rexLiteral1 = rexBuilder.makeLiteral("1");
                 RexNode condition = rexBuilder.makeCall(SqlStdOperatorTable.EQUALS, rexLiteral, rexLiteral1);
-                RelNode left = getDingoGetVectorByDistance(condition, replaceVector);
+                RelNode left = getDingoGetVectorByDistance(condition, replaceVector, true);
                 newLogicalJoin.replaceInput(0, left);
                 call.transformTo(newLogicalJoin);
             }

--- a/dingo-exec/src/main/java/io/dingodb/exec/channel/ReceiveEndpoint.java
+++ b/dingo-exec/src/main/java/io/dingodb/exec/channel/ReceiveEndpoint.java
@@ -34,7 +34,7 @@ import static io.dingodb.exec.Services.CTRL_TAG;
 
 @Slf4j
 public class ReceiveEndpoint {
-    private static final int BUFFER_LENGTH = 65536 * 3;
+    private static final int BUFFER_LENGTH = 65536 * 9;
 
     private final String host;
     private final int port;


### PR DESCRIPTION
1. 原因在于向量维度比较大，一批次数据的长度超过了buffer_length的长度导致卡住