### PR TITLE
[fix][dingo-calcite] Fork common pool blocking

### DIFF
--- a/dingo-calcite/src/main/java/io/dingodb/calcite/visitor/function/DingoStreamingConverterVisitFun.java
+++ b/dingo-calcite/src/main/java/io/dingodb/calcite/visitor/function/DingoStreamingConverterVisitFun.java
@@ -29,6 +29,7 @@ import io.dingodb.calcite.utils.TableInfo;
 import io.dingodb.calcite.visitor.DingoJobVisitor;
 import io.dingodb.cluster.ClusterService;
 import io.dingodb.common.Location;
+import io.dingodb.common.config.DingoConfiguration;
 import io.dingodb.common.partition.RangeDistribution;
 import io.dingodb.common.type.DingoType;
 import io.dingodb.common.type.TupleMapping;
@@ -229,7 +230,13 @@ public class DingoStreamingConverterVisitFun {
             Vertex vertex = new Vertex(HASH, param);
             vertex.setId(idGenerator.getOperatorId(task.getId()));
             OutputHint hint = new OutputHint();
-            hint.setLocation(locations.get(0));
+            Location location;
+            if (locations.size() == 0) {
+                location = DingoConfiguration.location();
+            } else {
+                location = locations.get(0);
+            }
+            hint.setLocation(location);
             vertex.setHint(hint);
             Edge edge = new Edge(input, vertex);
             vertex.addIn(edge);

--- a/dingo-common/src/main/java/io/dingodb/common/concurrent/Executors.java
+++ b/dingo-common/src/main/java/io/dingodb/common/concurrent/Executors.java
@@ -38,6 +38,7 @@ public final class Executors {
     private static final String FREE_THREAD_NAME = "FREE";
 
     public static final String GLOBAL_NAME = "GLOBAL";
+    public static final String COMPLETABLE_FUTURE = "COMPLETABLE_FUTURE";
     public static final String GLOBAL_SCHEDULE_NAME = "GLOBAL_SCHEDULE";
 
     private static final ThreadPoolExecutor GLOBAL_POOL = new ThreadPoolBuilder()
@@ -48,6 +49,16 @@ public final class Executors {
         .workQueue(new SynchronousQueue<>())
         .daemon(true)
         .group(new ThreadGroup(GLOBAL_NAME))
+        .build();
+
+    public static final ThreadPoolExecutor COMPLETABLE_FUTURE_POOL = new ThreadPoolBuilder()
+        .name(COMPLETABLE_FUTURE)
+        .coreThreads(0)
+        .maximumThreads(Integer.MAX_VALUE)
+        .keepAliveSeconds(TimeUnit.MINUTES.toSeconds(1))
+        .workQueue(new SynchronousQueue<>())
+        .daemon(true)
+        .group(new ThreadGroup(COMPLETABLE_FUTURE))
         .build();
 
     private static final ScheduledThreadPoolExecutor GLOBAL_SCHEDULE_POOL = new ThreadPoolBuilder()

--- a/dingo-driver/client/src/main/java/io/dingodb/driver/client/DingoDriverClient.java
+++ b/dingo-driver/client/src/main/java/io/dingodb/driver/client/DingoDriverClient.java
@@ -113,6 +113,7 @@ public class DingoDriverClient extends Driver {
             try {
                 return super.connect(url, info);
             } catch (Throwable e) {
+                log.error(e.getMessage(), e);
                 throw Helper.INSTANCE.createException("connect failed");
             }
         }

--- a/dingo-driver/host/src/main/java/io/dingodb/driver/ServerMeta.java
+++ b/dingo-driver/host/src/main/java/io/dingodb/driver/ServerMeta.java
@@ -692,6 +692,7 @@ public class ServerMeta implements Meta {
             try {
                 IdentityAuthService.INSTANCE.validate(authentication);
             } catch (Exception e) {
+                log.error(e.getMessage(), e);
                 throw new RuntimeException(e);
             }
         }


### PR DESCRIPTION
1.  fork common pool 线程池被占满，在unlock时用了独立的线程池
2. jarvex点击时偶尔调用getExecutorMap接口返回数据为空