### PR TITLE
[feature] [dingo-executor] Document  search UDF

### DIFF
--- a/dingo-calcite/src/main/codegen/config.fmpp
+++ b/dingo-calcite/src/main/codegen/config.fmpp
@@ -205,6 +205,7 @@ data: {
       "TENANTS"
       "REMARKS"
       "RENAME"
+      "TEXT_SEARCH"
     ]
 
     # List of non-reserved keywords to add;

--- a/dingo-calcite/src/main/codegen/includes/parserImpls.ftl
+++ b/dingo-calcite/src/main/codegen/includes/parserImpls.ftl
@@ -1221,5 +1221,21 @@ SqlNode TableFunctionCall() :
         {
             return SqlUserDefinedOperators.VECTOR.createCall(s.end(this), list);
         }
+    |
+        <TEXT> { s = span(); } <LPAREN>
+        [
+            AddArg0(list, ExprContext.ACCEPT_CURSOR)
+            (
+                <COMMA> {
+                    // a comma-list can't appear where only a query is expected
+                    checkNonQueryExpression(ExprContext.ACCEPT_CURSOR);
+                }
+                AddArg(list, ExprContext.ACCEPT_CURSOR)
+            )*
+        ]
+        <RPAREN>
+        {
+            return SqlUserDefinedOperators.TEXT.createCall(s.end(this), list);
+        }
     )
 }

--- a/dingo-calcite/src/main/codegen/includes/parserImpls.ftl
+++ b/dingo-calcite/src/main/codegen/includes/parserImpls.ftl
@@ -1222,7 +1222,7 @@ SqlNode TableFunctionCall() :
             return SqlUserDefinedOperators.VECTOR.createCall(s.end(this), list);
         }
     |
-        <TEXT> { s = span(); } <LPAREN>
+        <TEXT_SEARCH> { s = span(); } <LPAREN>
         [
             AddArg0(list, ExprContext.ACCEPT_CURSOR)
             (
@@ -1235,7 +1235,7 @@ SqlNode TableFunctionCall() :
         ]
         <RPAREN>
         {
-            return SqlUserDefinedOperators.TEXT.createCall(s.end(this), list);
+            return SqlUserDefinedOperators.TEXT_SEARCH.createCall(s.end(this), list);
         }
     )
 }

--- a/dingo-calcite/src/main/java/io/dingodb/calcite/DingoParserContext.java
+++ b/dingo-calcite/src/main/java/io/dingodb/calcite/DingoParserContext.java
@@ -136,7 +136,7 @@ public final class DingoParserContext implements Context {
         tableInstance.register(SqlUserDefinedOperators.LIKE_BINARY);
         tableInstance.register(SqlUserDefinedOperators.NOT_LIKE_BINARY);
         tableInstance.register(SqlUserDefinedOperators.SCAN);
-        tableInstance.register(SqlUserDefinedOperators.DOCUMENT);
+        tableInstance.register(SqlUserDefinedOperators.TEXT);
         SqlLikeBinaryOperator.register();
         SqlFunctionScanOperator.register(this);
         SqlVectorOperator.register(this);

--- a/dingo-calcite/src/main/java/io/dingodb/calcite/DingoParserContext.java
+++ b/dingo-calcite/src/main/java/io/dingodb/calcite/DingoParserContext.java
@@ -136,7 +136,7 @@ public final class DingoParserContext implements Context {
         tableInstance.register(SqlUserDefinedOperators.LIKE_BINARY);
         tableInstance.register(SqlUserDefinedOperators.NOT_LIKE_BINARY);
         tableInstance.register(SqlUserDefinedOperators.SCAN);
-        tableInstance.register(SqlUserDefinedOperators.TEXT);
+        tableInstance.register(SqlUserDefinedOperators.TEXT_SEARCH);
         SqlLikeBinaryOperator.register();
         SqlFunctionScanOperator.register(this);
         SqlVectorOperator.register(this);

--- a/dingo-calcite/src/main/java/io/dingodb/calcite/DingoSqlToRelConverter.java
+++ b/dingo-calcite/src/main/java/io/dingodb/calcite/DingoSqlToRelConverter.java
@@ -17,6 +17,7 @@
 package io.dingodb.calcite;
 
 import io.dingodb.calcite.rel.DingoFunctionScan;
+import io.dingodb.calcite.rel.LogicalDingoDocument;
 import io.dingodb.calcite.rel.LogicalDingoVector;
 import io.dingodb.calcite.traits.DingoConvention;
 import org.apache.calcite.plan.RelOptCluster;
@@ -127,6 +128,21 @@ class DingoSqlToRelConverter extends SqlToRelConverter {
             assert namespace != null;
             List<Object> operands = new ArrayList<>(call.getOperandList());
             callRel = new LogicalDingoVector(
+                cluster,
+                traits,
+                (RexCall) rexCall,
+                namespace.getTable(),
+                operands,
+                namespace.getIndex().getTableId(),
+                namespace.getIndex(),
+                null,
+                null,
+                new ArrayList<>()
+            );
+        } else if (operator instanceof SqlDocumentOperator) {
+            assert namespace != null;
+            List<Object> operands = new ArrayList<>(call.getOperandList());
+            callRel = new LogicalDingoDocument(
                 cluster,
                 traits,
                 (RexCall) rexCall,

--- a/dingo-calcite/src/main/java/io/dingodb/calcite/grammar/SqlUserDefinedOperators.java
+++ b/dingo-calcite/src/main/java/io/dingodb/calcite/grammar/SqlUserDefinedOperators.java
@@ -40,9 +40,9 @@ public class SqlUserDefinedOperators {
 
     public static SqlVectorOperator VECTOR = new SqlVectorOperator("VECTOR", SqlKind.COLLECTION_TABLE);
 
-//    public static SqlDocumentOperator DOCUMENT = new SqlDocumentOperator("DOCUMENT", SqlKind.COLLECTION_TABLE );
+    public static SqlDocumentOperator DOCUMENT = new SqlDocumentOperator("TEXT", SqlKind.COLLECTION_TABLE );
 
-    public static SqlDocumentOperator TEXT = new SqlDocumentOperator("TEXT", SqlKind.COLLECTION_TABLE);
+    public static SqlDocumentOperator TEXT_SEARCH = new SqlDocumentOperator("TEXT_SEARCH", SqlKind.COLLECTION_TABLE);
 
     public static SqlCosineSimilarityOperator COSINE_SIMILARITY
         = new SqlCosineSimilarityOperator(VectorCosineDistanceFun.NAME, SqlKind.OTHER_FUNCTION);

--- a/dingo-calcite/src/main/java/io/dingodb/calcite/grammar/SqlUserDefinedOperators.java
+++ b/dingo-calcite/src/main/java/io/dingodb/calcite/grammar/SqlUserDefinedOperators.java
@@ -40,7 +40,9 @@ public class SqlUserDefinedOperators {
 
     public static SqlVectorOperator VECTOR = new SqlVectorOperator("VECTOR", SqlKind.COLLECTION_TABLE);
 
-    public static SqlDocumentOperator DOCUMENT = new SqlDocumentOperator("TEXT", SqlKind.COLLECTION_TABLE);
+//    public static SqlDocumentOperator DOCUMENT = new SqlDocumentOperator("DOCUMENT", SqlKind.COLLECTION_TABLE );
+
+    public static SqlDocumentOperator TEXT = new SqlDocumentOperator("TEXT", SqlKind.COLLECTION_TABLE);
 
     public static SqlCosineSimilarityOperator COSINE_SIMILARITY
         = new SqlCosineSimilarityOperator(VectorCosineDistanceFun.NAME, SqlKind.OTHER_FUNCTION);
@@ -50,5 +52,7 @@ public class SqlUserDefinedOperators {
 
     public static SqlL2DistanceOperator L2_DISTANCE
         = new SqlL2DistanceOperator(VectorL2DistanceFun.NAME, SqlKind.OTHER_FUNCTION);
+
+
 
 }

--- a/dingo-calcite/src/main/java/io/dingodb/calcite/rel/DingoDocument.java
+++ b/dingo-calcite/src/main/java/io/dingodb/calcite/rel/DingoDocument.java
@@ -1,0 +1,94 @@
+/*
+ * Copyright 2021 DataCanvas
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package io.dingodb.calcite.rel;
+
+import io.dingodb.calcite.DingoRelOptTable;
+import io.dingodb.calcite.utils.RelDataTypeUtils;
+import io.dingodb.calcite.visitor.DingoRelVisitor;
+import io.dingodb.common.CommonId;
+import io.dingodb.common.type.TupleMapping;
+import io.dingodb.meta.entity.Table;
+import lombok.Getter;
+import org.apache.calcite.plan.RelOptCluster;
+import org.apache.calcite.plan.RelOptCost;
+import org.apache.calcite.plan.RelOptPlanner;
+import org.apache.calcite.plan.RelTraitSet;
+import org.apache.calcite.rel.RelWriter;
+import org.apache.calcite.rel.hint.RelHint;
+import org.apache.calcite.rel.metadata.RelMetadataQuery;
+import org.apache.calcite.rel.type.RelDataType;
+import org.apache.calcite.rex.RexCall;
+import org.apache.calcite.rex.RexNode;
+import org.checkerframework.checker.nullness.qual.NonNull;
+import org.checkerframework.checker.nullness.qual.Nullable;
+
+import java.util.List;
+
+public class DingoDocument extends LogicalDingoDocument implements DingoRel {
+    @Getter
+    private double rowCount;
+
+    public DingoDocument(
+        RelOptCluster cluster,
+        RelTraitSet traitSet,
+        RexCall call,
+        DingoRelOptTable table,
+        List<Object> operands,
+        @NonNull CommonId indexTableId,
+        @NonNull Table indexTable,
+        TupleMapping selection,
+        RexNode filter,
+        List<RelHint> hints
+    ) {
+        super(cluster, traitSet, call, table, operands, indexTableId, indexTable, selection, filter, hints);
+    }
+
+    @Override
+    public @Nullable RelOptCost computeSelfCost(@NonNull RelOptPlanner planner, @NonNull RelMetadataQuery mq) {
+        return DingoCost.FACTORY.makeCost(Integer.MAX_VALUE, 0, 0);
+    }
+
+    @Override
+    public @NonNull RelWriter explainTerms(@NonNull RelWriter pw) {
+        super.explainTerms(pw);
+        // crucial, this is how Calcite distinguish between different node with different props.
+        return pw;
+    }
+
+    @Override
+    public <T> T accept(@NonNull DingoRelVisitor<T> visitor) {
+        return visitor.visit(this);
+    }
+
+    public RelDataType getNormalRowType() {
+        return getNormalSelectedType();
+    }
+
+    private RelDataType getNormalSelectedType() {
+        return RelDataTypeUtils.mapType(
+            getCluster().getTypeFactory(),
+            getTableType(),
+            selection
+        );
+    }
+
+    @Override
+    public double estimateRowCount(RelMetadataQuery mq) {
+        rowCount = super.estimateRowCount(mq);
+        return rowCount;
+    }
+}

--- a/dingo-calcite/src/main/java/io/dingodb/calcite/rel/DocumentStreamConvertor.java
+++ b/dingo-calcite/src/main/java/io/dingodb/calcite/rel/DocumentStreamConvertor.java
@@ -1,0 +1,92 @@
+/*
+ * Copyright 2021 DataCanvas
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package io.dingodb.calcite.rel;
+
+import io.dingodb.calcite.visitor.DingoRelVisitor;
+import io.dingodb.common.CommonId;
+import io.dingodb.meta.entity.Table;
+import lombok.Getter;
+import org.apache.calcite.plan.RelOptCluster;
+import org.apache.calcite.plan.RelOptCost;
+import org.apache.calcite.plan.RelOptPlanner;
+import org.apache.calcite.plan.RelTraitSet;
+import org.apache.calcite.rel.RelNode;
+import org.apache.calcite.rel.SingleRel;
+import org.apache.calcite.rel.metadata.RelMetadataQuery;
+import org.checkerframework.checker.nullness.qual.NonNull;
+import org.checkerframework.checker.nullness.qual.Nullable;
+
+import java.util.List;
+
+public class DocumentStreamConvertor extends SingleRel implements DingoRel {
+
+    @Getter
+    private CommonId indexId;
+
+    @Getter
+    private Integer documentIdIndex;
+
+    @Getter
+    private Table indexTableDefinition;
+
+    @Getter
+    private boolean needRoute;
+
+    /**
+     * Creates a <code>SingleRel</code>.
+     *
+     * @param cluster Cluster this relational expression belongs to
+     * @param traits convention root streaming empty
+     * @param input   Input relational expression
+     */
+    public DocumentStreamConvertor(RelOptCluster cluster,
+                                 RelTraitSet traits,
+                                 RelNode input,
+                                 CommonId indexId,
+                                 Integer documentIdIndex,
+                                 Table indexTableDefinition,
+                                 boolean needRoute) {
+        super(cluster, traits, input);
+        this.indexId = indexId;
+        this.documentIdIndex = documentIdIndex;
+        this.indexTableDefinition = indexTableDefinition;
+        this.needRoute = needRoute;
+    }
+
+    @Override
+    public <T> T accept(@NonNull DingoRelVisitor<T> visitor) {
+        return visitor.visit(this);
+    }
+
+    @Override
+    public RelNode copy(RelTraitSet traitSet, List<RelNode> inputs) {
+        return new DocumentStreamConvertor(
+            getCluster(),
+            traitSet,
+            sole(inputs),
+            indexId,
+            documentIdIndex,
+            indexTableDefinition,
+            needRoute);
+    }
+
+    @Override
+    public @Nullable RelOptCost computeSelfCost(RelOptPlanner planner, RelMetadataQuery mq) {
+        return DingoCost.FACTORY.makeTinyCost();
+    }
+
+}

--- a/dingo-calcite/src/main/java/io/dingodb/calcite/rel/DocumentTableDataScan.java
+++ b/dingo-calcite/src/main/java/io/dingodb/calcite/rel/DocumentTableDataScan.java
@@ -1,0 +1,48 @@
+/*
+ * Copyright 2021 DataCanvas
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package io.dingodb.calcite.rel;
+
+import io.dingodb.calcite.visitor.DingoRelVisitor;
+import org.apache.calcite.plan.RelOptCluster;
+import org.apache.calcite.plan.RelOptCost;
+import org.apache.calcite.plan.RelOptPlanner;
+import org.apache.calcite.plan.RelOptTable;
+import org.apache.calcite.plan.RelTraitSet;
+import org.apache.calcite.rel.core.TableScan;
+import org.apache.calcite.rel.hint.RelHint;
+import org.apache.calcite.rel.metadata.RelMetadataQuery;
+import org.checkerframework.checker.nullness.qual.NonNull;
+import org.checkerframework.checker.nullness.qual.Nullable;
+
+import java.util.List;
+
+public class DocumentTableDataScan extends TableScan implements DingoRel {
+    public DocumentTableDataScan(RelOptCluster cluster, RelTraitSet traitSet, List<RelHint> hints, RelOptTable table) {
+        super(cluster, traitSet, hints, table);
+    }
+
+    @Override
+    public <T> T accept(@NonNull DingoRelVisitor<T> visitor) {
+        //return visitor.visit(DocumentTableDataScan);
+        return null;
+    }
+
+    @Override
+    public @Nullable RelOptCost computeSelfCost(RelOptPlanner planner, RelMetadataQuery mq) {
+        return DingoCost.FACTORY.makeTinyCost();
+    }
+}

--- a/dingo-calcite/src/main/java/io/dingodb/calcite/rel/LogicalDingoDocument.java
+++ b/dingo-calcite/src/main/java/io/dingodb/calcite/rel/LogicalDingoDocument.java
@@ -1,0 +1,204 @@
+/*
+ * Copyright 2021 DataCanvas
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package io.dingodb.calcite.rel;
+
+import io.dingodb.calcite.DingoRelOptTable;
+import io.dingodb.calcite.DingoTable;
+import io.dingodb.calcite.utils.RelDataTypeUtils;
+import io.dingodb.common.CommonId;
+import io.dingodb.common.type.DingoType;
+import io.dingodb.common.type.DingoTypeFactory;
+import io.dingodb.common.type.TupleMapping;
+import io.dingodb.common.type.TupleType;
+import io.dingodb.common.type.scalar.FloatType;
+import io.dingodb.meta.entity.Column;
+import io.dingodb.meta.entity.Table;
+import lombok.Getter;
+import lombok.Setter;
+import org.apache.calcite.plan.RelOptCluster;
+import org.apache.calcite.plan.RelTraitSet;
+import org.apache.calcite.rel.RelNode;
+import org.apache.calcite.rel.RelWriter;
+import org.apache.calcite.rel.core.TableFunctionScan;
+import org.apache.calcite.rel.hint.RelHint;
+import org.apache.calcite.rel.metadata.RelColumnMapping;
+import org.apache.calcite.rel.type.RelDataType;
+import org.apache.calcite.rel.type.RelDataTypeFactory;
+import org.apache.calcite.rel.type.RelDataTypeFieldImpl;
+import org.apache.calcite.rex.RexCall;
+import org.apache.calcite.rex.RexNode;
+import org.apache.calcite.sql.type.SqlTypeName;
+import org.checkerframework.checker.nullness.qual.NonNull;
+import org.checkerframework.checker.nullness.qual.Nullable;
+
+import java.lang.reflect.Type;
+import java.util.ArrayList;
+import java.util.Collections;
+import java.util.List;
+import java.util.Set;
+import java.util.stream.Collectors;
+
+public class LogicalDingoDocument extends TableFunctionScan {
+
+    @Getter
+    private final RexCall call;
+    @Getter
+    private final DingoRelOptTable table;
+    @Getter
+    private final List<Object> operands;
+    @Getter
+    private final CommonId indexTableId;
+    @Getter
+    private final Table indexTable;
+    @Getter
+    protected final TupleMapping selection;
+    @Getter
+    protected TupleMapping realSelection;
+
+    @Getter
+    protected final RexNode filter;
+
+    @Getter
+    @Setter
+    protected boolean forDml;
+
+    @Getter
+    public List<RelHint> hints;
+
+    public LogicalDingoDocument(RelOptCluster cluster,
+                                 RelTraitSet traitSet,
+                                 RexCall call,
+                                 DingoRelOptTable table,
+                                 List<Object> operands,
+                                 @NonNull CommonId indexTableId,
+                                 @NonNull Table indexTable,
+                                 TupleMapping selection,
+                                 RexNode filter,
+                                 List<RelHint> hints
+                              ) {
+        super(cluster, traitSet, Collections.emptyList(), call, null, call.type, null);
+        this.call = call;
+        this.table = table;
+        this.operands = operands;
+        this.indexTableId = indexTableId;
+        this.indexTable = indexTable;
+        this.filter = filter;
+        this.rowType = null;
+        this.realSelection = selection;
+        this.hints = hints;
+        DingoTable dingoTable = table.unwrap(DingoTable.class);
+        if (selection != null) {
+            if (forDml) {
+                this.selection = selection;
+            } else {
+                List<Integer> mappingList = new ArrayList<>();
+                for (int index : selection.getMappings()) {
+                    if (index < dingoTable.getTable().getColumns().size()) {
+                        if (dingoTable.getTable().getColumns().get(index).getState() == 1) {
+                            mappingList.add(index);
+                        }
+                    } else {
+                        mappingList.add(index);
+                    }
+                }
+                this.selection = TupleMapping.of(mappingList);
+            }
+        } else {
+            assert dingoTable != null;
+            List<Integer> mapping = dingoTable.getTable()
+                .getColumns()
+                .stream()
+                .filter(col -> col.getState() == 1)
+                .map(col -> dingoTable.getTable().getColumns().indexOf(col))
+                .collect(Collectors.toList());
+            mapping.add(dingoTable.getTable().getColumns().size());
+            this.selection = TupleMapping.of(mapping);
+        }
+    }
+
+    @Override
+    public boolean deepEquals(@Nullable Object obj) {
+        if (obj instanceof LogicalDingoDocument) {
+            LogicalDingoDocument that = (LogicalDingoDocument) obj;
+            boolean result = super.deepEquals(obj);
+            return result && that.filter == filter
+                && that.realSelection == realSelection && that.selection == selection;
+        }
+        return false;
+    }
+
+    @Override
+    public TableFunctionScan copy(RelTraitSet traitSet,
+                                  List<RelNode> inputs,
+                                  RexNode rexCall,
+                                  @Nullable Type elementType,
+                                  RelDataType rowType,
+                                  @Nullable Set<RelColumnMapping> columnMappings) {
+        return new LogicalDingoDocument(
+            getCluster(),
+            traitSet,
+            call, table, operands, indexTableId, indexTable, selection, filter, hints);
+    }
+
+    @Override
+    public @NonNull RelWriter explainTerms(@NonNull RelWriter pw) {
+        super.explainTerms(pw);
+        // crucial, this is how Calcite distinguish between different node with different props.
+        return pw;
+    }
+
+    @Override
+    protected RelDataType deriveRowType() {
+        return getSelectedType();
+    }
+
+    public RelDataType getSelectedType() {
+        return RelDataTypeUtils.mapType(
+            getCluster().getTypeFactory(),
+            getTableType(),
+            realSelection
+        );
+    }
+
+    public RelDataType getTableType() {
+        RelDataType relDataType = table.getRowType();
+        RelDataTypeFactory.Builder builder = getCluster().getTypeFactory().builder();
+        builder.addAll(relDataType.getFieldList());
+        builder.add(new RelDataTypeFieldImpl(
+            indexTable.getName() + "$rank_bm25",
+            relDataType.getFieldCount(),
+            getCluster().getTypeFactory().createSqlType(SqlTypeName.get("FLOAT"))));
+        return builder.build();
+    }
+
+    public TupleType tupleType() {
+        DingoTable dingoTable = table.unwrap(DingoTable.class);
+        assert dingoTable != null;
+        ArrayList<Column> cols = new ArrayList<>(dingoTable.getTable().columns.size() + 1);
+        cols.addAll(dingoTable.getTable().columns);
+        cols.add(Column
+            .builder()
+            .name(indexTable.getName().concat("$rank_bm25"))
+            .sqlTypeName("FLOAT")
+            .type(new FloatType(false))
+            .precision(-1)
+            .scale(-2147483648)
+            .build());
+        return DingoTypeFactory.tuple(cols.stream().map(Column::getType).toArray(DingoType[]::new));
+    }
+
+}

--- a/dingo-calcite/src/main/java/io/dingodb/calcite/rule/DingoDocumentFilterRule.java
+++ b/dingo-calcite/src/main/java/io/dingodb/calcite/rule/DingoDocumentFilterRule.java
@@ -1,0 +1,86 @@
+/*
+ * Copyright 2021 DataCanvas
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package io.dingodb.calcite.rule;
+
+import io.dingodb.calcite.DingoTable;
+import io.dingodb.calcite.rel.LogicalDingoDocument;
+import org.apache.calcite.plan.RelOptRuleCall;
+import org.apache.calcite.plan.RelRule;
+import org.apache.calcite.rel.logical.LogicalFilter;
+import org.apache.calcite.rel.rules.SubstitutionRule;
+import org.immutables.value.Value;
+
+@Value.Enclosing
+public class DingoDocumentFilterRule extends RelRule<DingoDocumentFilterRule.Config> implements SubstitutionRule {
+
+    public DingoDocumentFilterRule(Config config) {
+        super(config);
+    }
+
+    @Override
+    public void onMatch(RelOptRuleCall call) {
+        final LogicalFilter filter = call.rel(0);
+        final LogicalDingoDocument document = call.rel(1);
+        call.transformTo(
+            new LogicalDingoDocument(
+                document.getCluster(),
+                document.getTraitSet(),
+                document.getCall(),
+                document.getTable(),
+                document.getOperands(),
+                document.getIndexTableId(),
+                document.getIndexTable(),
+                document.getSelection(),
+                filter.getCondition(),
+                filter.getHints()
+            )
+        );
+    }
+
+    @Override
+    public boolean autoPruneOld() {
+        return true;
+    }
+
+    @Value.Immutable
+    public interface Config extends RelRule.Config {
+        DingoDocumentFilterRule.Config DEFAULT = ImmutableDingoDocumentFilterRule.Config.builder()
+            .operandSupplier(b0 ->
+                b0.operand(LogicalFilter.class).oneInput(b1 ->
+                    b1.operand(LogicalDingoDocument.class)
+                        .predicate(rel -> {
+                            boolean isFullSelection = rel.getRealSelection() == null;
+                            if (!isFullSelection) {
+                                DingoTable dingoTable = rel.getTable().unwrap(DingoTable.class);
+                                assert dingoTable != null;
+                                isFullSelection = rel.getRealSelection().size()
+                                    == dingoTable.getTable().getColumns().size();
+                            }
+                            return isFullSelection && rel.getFilter() == null;
+                        } )
+                        .noInputs()
+                )
+            )
+            .description("DingoDocumentFilterRule")
+            .build();
+
+        @Override
+        default DingoDocumentFilterRule toRule() {
+            return new DingoDocumentFilterRule(this);
+        }
+    }
+}

--- a/dingo-calcite/src/main/java/io/dingodb/calcite/rule/DingoDocumentIndexRule.java
+++ b/dingo-calcite/src/main/java/io/dingodb/calcite/rule/DingoDocumentIndexRule.java
@@ -1,0 +1,181 @@
+/*
+ * Copyright 2021 DataCanvas
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package io.dingodb.calcite.rule;
+
+import com.google.common.collect.ImmutableList;
+import io.dingodb.calcite.DingoTable;
+import io.dingodb.calcite.rel.DingoGetByIndex;
+import io.dingodb.calcite.rel.DingoGetByIndexMerge;
+import io.dingodb.calcite.rel.DingoGetByKeys;
+import io.dingodb.calcite.rel.DingoTableScan;
+import io.dingodb.calcite.rel.DingoDocument;
+import io.dingodb.calcite.rel.LogicalDingoDocument;
+import io.dingodb.calcite.rel.DocumentStreamConvertor;
+import io.dingodb.calcite.rel.dingo.DingoStreamingConverter;
+import io.dingodb.calcite.traits.DingoConvention;
+import io.dingodb.calcite.traits.DingoRelStreaming;
+import io.dingodb.calcite.utils.IndexValueMapSet;
+import io.dingodb.calcite.utils.IndexValueMapSetVisitor;
+import io.dingodb.common.CommonId;
+import io.dingodb.common.type.TupleMapping;
+import io.dingodb.common.util.Pair;
+import io.dingodb.meta.entity.Column;
+import io.dingodb.meta.entity.IndexTable;
+import io.dingodb.meta.entity.Table;
+import lombok.extern.slf4j.Slf4j;
+import org.apache.calcite.plan.RelOptRuleCall;
+import org.apache.calcite.plan.RelRule;
+import org.apache.calcite.plan.RelTraitSet;
+import org.apache.calcite.rel.RelNode;
+import org.apache.calcite.rex.RexNode;
+import org.apache.calcite.rex.RexUtil;
+import org.immutables.value.Value;
+
+import java.util.Arrays;
+import java.util.List;
+import java.util.Map;
+import java.util.Set;
+import java.util.stream.Collectors;
+
+import static io.dingodb.calcite.rel.LogicalDingoTableScan.dispatchDistanceCondition;
+import static io.dingodb.calcite.rule.DingoGetByIndexRule.filterIndices;
+import static io.dingodb.calcite.rule.DingoGetByIndexRule.filterScalarIndices;
+import static io.dingodb.calcite.rule.DingoGetByIndexRule.getScalaIndices;
+
+@Slf4j
+@Value.Enclosing
+public class DingoDocumentIndexRule extends RelRule<RelRule.Config> {
+
+    /**
+     * Creates a RelRule.
+     *
+     * @param config config
+     */
+    protected DingoDocumentIndexRule(Config config) {
+        super(config);
+    }
+
+    @Override
+    public void onMatch(RelOptRuleCall call) {
+        DingoDocument document = call.rel(0);
+//        RelNode relNode = getDingoGetDocumentByToken(document.getFilter(), document, false);
+        RelNode relNode = null;
+        if (relNode == null) {
+            return;
+        }
+        call.transformTo(relNode);
+    }
+    private static DingoGetByIndex preScalarRelNode(LogicalDingoDocument dingoDocument,
+                                         IndexValueMapSet<Integer, RexNode> indexValueMapSet,
+                                         Table td,
+                                         TupleMapping selection,
+                                         RexNode condition) {
+        Map<CommonId, Table> indexTdMap = getScalaIndices(dingoDocument.getTable());
+
+        if (indexTdMap.isEmpty()) {
+            return null;
+        }
+        Map<CommonId, Set> indexSetMap = filterScalarIndices(
+            indexValueMapSet,
+            indexTdMap,
+            selection,
+            td);
+        if (indexSetMap == null) {
+            return null;
+        }
+        if (indexSetMap.size() > 1) {
+            return new DingoGetByIndexMerge(
+                dingoDocument.getCluster(),
+                dingoDocument.getTraitSet(),
+                ImmutableList.of(),
+                dingoDocument.getTable(),
+                condition,
+                selection,
+                false,
+                indexSetMap,
+                indexTdMap,
+                td.keyMapping()
+            );
+        } else {
+            return new DingoGetByIndex(
+                dingoDocument.getCluster(),
+                dingoDocument.getTraitSet(),
+                ImmutableList.of(),
+                dingoDocument.getTable(),
+                condition,
+                selection,
+                false,
+                indexSetMap,
+                indexTdMap
+            );
+        }
+    }
+
+    @Value.Immutable
+    public interface Config extends RelRule.Config {
+        Config DEFAULT = ImmutableDingoDocumentIndexRule.Config.builder()
+            .description("DingoDocumentIndexRule")
+            .operandSupplier(b0 ->
+                b0.operand(DingoDocument.class).predicate(rel -> rel.getFilter() != null).noInputs()
+            )
+            .build();
+
+        @Override
+        default DingoDocumentIndexRule toRule() {
+            return new DingoDocumentIndexRule(this);
+        }
+    }
+
+    private static Pair<Integer, Integer> getDocumentIndex(DingoTable dingoTable, int dimension) {
+        List<IndexTable> indexes = dingoTable.getTable().getIndexes();
+        for (IndexTable index : indexes) {
+
+            if (!index.getIndexType().isVector) {
+                continue;
+            }
+
+            int dimension1 = Integer.parseInt(index.getProperties().getProperty("dimension"));
+            if (dimension != dimension1) {
+                continue;
+            }
+            String documentIdColName = index.getColumns().get(0).getName();
+            String documentColName = index.getColumns().get(1).getName();
+            int documentIdIndex = 0;
+            int documentIndex = 0;
+            for (int i = 0; i < dingoTable.getTable().getColumns().size(); i ++) {
+                Column column = dingoTable.getTable().getColumns().get(i);
+                if (column.getName().equals(documentIdColName)) {
+                    documentIdIndex = i;
+                } else if (column.getName().equals(documentColName)) {
+                    documentIndex = i;
+                }
+            }
+            return Pair.of(documentIdIndex, documentIndex);
+        }
+        return null;
+    }
+
+    public static TupleMapping getDefaultSelection(DingoTable dingoTable) {
+        int columnsCount = dingoTable.getTable().getColumns().size();
+        int[] mappings = new int[columnsCount];
+        for (int i = 0; i < columnsCount; i ++) {
+            mappings[i] = i;
+        }
+        return TupleMapping.of(mappings);
+    }
+
+}

--- a/dingo-calcite/src/main/java/io/dingodb/calcite/rule/DingoDocumentJoinRule.java
+++ b/dingo-calcite/src/main/java/io/dingodb/calcite/rule/DingoDocumentJoinRule.java
@@ -1,0 +1,107 @@
+/*
+ * Copyright 2021 DataCanvas
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package io.dingodb.calcite.rule;
+
+import io.dingodb.calcite.rel.LogicalDingoDocument;
+import io.dingodb.calcite.rel.LogicalDingoVector;
+import io.dingodb.calcite.rule.dingo.DingoHashJoinRule;
+import io.dingodb.calcite.traits.DingoConvention;
+import io.dingodb.calcite.traits.DingoRelStreaming;
+import io.dingodb.calcite.type.DingoSqlTypeFactory;
+import org.apache.calcite.plan.RelOptRuleCall;
+import org.apache.calcite.plan.RelRule;
+import org.apache.calcite.plan.RelTraitSet;
+import org.apache.calcite.plan.volcano.RelSubset;
+import org.apache.calcite.rel.RelNode;
+import org.apache.calcite.rel.logical.LogicalJoin;
+import org.apache.calcite.rex.RexBuilder;
+import org.apache.calcite.rex.RexLiteral;
+import org.apache.calcite.rex.RexNode;
+import org.apache.calcite.sql.fun.SqlStdOperatorTable;
+import org.immutables.value.Value;
+
+import static io.dingodb.calcite.rule.DingoVectorIndexRule.getDingoGetVectorByDistance;
+
+@Value.Enclosing
+public class DingoDocumentJoinRule extends RelRule<DingoDocumentJoinRule.Config>  {
+    /**
+     * Creates a RelRule.
+     *
+     * @param config
+     */
+    public DingoDocumentJoinRule(Config config) {
+        super(config);
+    }
+
+    @Override
+    public void onMatch(RelOptRuleCall call) {
+        LogicalJoin logicalJoin = call.rel(0);
+
+        LogicalJoin newLogicalJoin = (LogicalJoin) logicalJoin.copy(logicalJoin.getTraitSet(), logicalJoin.getInputs());
+
+        RelSubset subset = (RelSubset) newLogicalJoin.getLeft();
+        if (subset.getRelList().size() == 1) {
+            RelNode relNode = subset.getBestOrOriginal();
+            if (relNode instanceof LogicalDingoDocument) {
+                LogicalDingoDocument document = (LogicalDingoDocument) relNode;
+                RelTraitSet traits = document.getTraitSet()
+                    .replace(DingoConvention.INSTANCE)
+                    .replace(DingoRelStreaming.of(document.getTable()));
+                LogicalDingoDocument replaceDoc = (LogicalDingoDocument) document.copy(traits, document.getInputs(),
+                    document.getCall(), document.getElementType(), document.getRowType(), document.getColumnMappings());
+                RexBuilder rexBuilder = new RexBuilder(DingoSqlTypeFactory.INSTANCE);
+                call.transformTo(newLogicalJoin);
+            }
+        }
+    }
+
+    @Value.Immutable
+    public interface Config extends RelRule.Config {
+        DingoDocumentJoinRule.Config DEFAULT = ImmutableDingoDocumentJoinRule.Config.builder()
+            .operandSupplier(b0 ->
+                b0.operand(LogicalJoin.class).predicate(rel -> {
+                    if (!DingoHashJoinRule.match(rel)) {
+                        return false;
+                    }
+                    if (rel.getHints().size() == 0) {
+                        return false;
+                    } else {
+                        if (!"document_pre".equalsIgnoreCase(rel.getHints().get(0).hintName)) {
+                            return false;
+                        }
+                    }
+                    if (rel.getLeft() instanceof RelSubset) {
+                        RelSubset subset = (RelSubset) rel.getLeft();
+                        if (subset.getRelList().size() == 1) {
+                            RelNode relNode = subset.getBestOrOriginal();
+                            if (relNode instanceof LogicalDingoDocument) {
+                                return true;
+                            }
+                        }
+                    }
+                    return false;
+                }).anyInputs()
+            )
+            .description("DingoDocumentJoinRule")
+            .build();
+
+        @Override
+        default DingoDocumentJoinRule toRule() {
+            return new DingoDocumentJoinRule(this);
+        }
+    }
+}

--- a/dingo-calcite/src/main/java/io/dingodb/calcite/rule/DingoDocumentJoinRule.java
+++ b/dingo-calcite/src/main/java/io/dingodb/calcite/rule/DingoDocumentJoinRule.java
@@ -17,7 +17,6 @@
 package io.dingodb.calcite.rule;
 
 import io.dingodb.calcite.rel.LogicalDingoDocument;
-import io.dingodb.calcite.rel.LogicalDingoVector;
 import io.dingodb.calcite.rule.dingo.DingoHashJoinRule;
 import io.dingodb.calcite.traits.DingoConvention;
 import io.dingodb.calcite.traits.DingoRelStreaming;
@@ -29,12 +28,8 @@ import org.apache.calcite.plan.volcano.RelSubset;
 import org.apache.calcite.rel.RelNode;
 import org.apache.calcite.rel.logical.LogicalJoin;
 import org.apache.calcite.rex.RexBuilder;
-import org.apache.calcite.rex.RexLiteral;
-import org.apache.calcite.rex.RexNode;
-import org.apache.calcite.sql.fun.SqlStdOperatorTable;
 import org.immutables.value.Value;
 
-import static io.dingodb.calcite.rule.DingoVectorIndexRule.getDingoGetVectorByDistance;
 
 @Value.Enclosing
 public class DingoDocumentJoinRule extends RelRule<DingoDocumentJoinRule.Config>  {

--- a/dingo-calcite/src/main/java/io/dingodb/calcite/rule/DingoDocumentProjectRule.java
+++ b/dingo-calcite/src/main/java/io/dingodb/calcite/rule/DingoDocumentProjectRule.java
@@ -1,0 +1,158 @@
+/*
+ * Copyright 2021 DataCanvas
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package io.dingodb.calcite.rule;
+
+import io.dingodb.calcite.DingoTable;
+import io.dingodb.calcite.grammar.SqlUserDefinedOperators;
+import io.dingodb.calcite.rel.LogicalDingoDocument;
+import io.dingodb.common.type.TupleMapping;
+import org.apache.calcite.plan.RelOptRuleCall;
+import org.apache.calcite.plan.RelRule;
+import org.apache.calcite.rel.logical.LogicalProject;
+import org.apache.calcite.rel.rules.SubstitutionRule;
+import org.apache.calcite.rex.RexCall;
+import org.apache.calcite.rex.RexInputRef;
+import org.apache.calcite.rex.RexNode;
+import org.apache.calcite.rex.RexUtil;
+import org.apache.calcite.rex.RexVisitorImpl;
+import org.apache.calcite.util.mapping.Mapping;
+import org.apache.calcite.util.mapping.Mappings;
+import org.checkerframework.checker.nullness.qual.NonNull;
+import org.checkerframework.checker.nullness.qual.Nullable;
+import org.immutables.value.Value;
+
+import java.util.ArrayList;
+import java.util.Comparator;
+import java.util.List;
+
+@Value.Enclosing
+public class DingoDocumentProjectRule extends RelRule<DingoDocumentProjectRule.Config> implements SubstitutionRule {
+
+    public DingoDocumentProjectRule(Config config) {
+        super(config);
+    }
+
+    @Override
+    public void onMatch(RelOptRuleCall call) {
+        final LogicalProject project = call.rel(0);
+        final LogicalDingoDocument document = call.rel(1);
+        final List<Integer> selectedColumns = new ArrayList<>();
+        final List<RexCall> documentSelected = new ArrayList<>();
+        final RexVisitorImpl<Void> visitor = new RexVisitorImpl<Void>(true) {
+            @Override
+            public @Nullable Void visitInputRef(@NonNull RexInputRef inputRef) {
+                if (!selectedColumns.contains(inputRef.getIndex())) {
+                    selectedColumns.add(inputRef.getIndex());
+                }
+                return null;
+            }
+
+            @Override
+            public Void visitCall(RexCall call) {
+                if (call.op.getName().equalsIgnoreCase(SqlUserDefinedOperators.COSINE_SIMILARITY.getName())
+                    || call.op.getName().equalsIgnoreCase(SqlUserDefinedOperators.IP_DISTANCE.getName())
+                    || call.op.getName().equalsIgnoreCase(SqlUserDefinedOperators.L2_DISTANCE.getName())) {
+                    documentSelected.add(call);
+                }
+                return super.visitCall(call);
+            }
+        };
+        List<RexNode> projects = project.getProjects();
+        RexNode filter = document.getFilter();
+        visitor.visitEach(projects);
+        if (filter != null) {
+            filter.accept(visitor);
+        }
+
+        /*
+          select id, distance from xx where not in (sub item size > 20)  -> generate same node to infinite loop
+          join
+          left: document scan -> logicalProject -> filter (cause infinite loop)
+          right: agg values
+          so break
+         */
+        if (projects.size() > selectedColumns.size()) {
+            return;
+        }
+        // Order naturally to help decoding in push down.
+        selectedColumns.sort(Comparator.naturalOrder());
+        Mapping mapping = Mappings.target(selectedColumns, document.getRowType().getFieldCount());
+
+        LogicalDingoDocument newDocument = new LogicalDingoDocument(
+            document.getCluster(),
+            document.getTraitSet(),
+            document.getCall(),
+            document.getTable(),
+            document.getOperands(),
+            document.getIndexTableId(),
+            document.getIndexTable(),
+            TupleMapping.of(selectedColumns),
+            filter,
+            document.hints
+        );
+        final List<RexNode> newProjectRexNodes = RexUtil.apply(mapping, project.getProjects());
+        if (RexUtil.isIdentity(newProjectRexNodes, newDocument.getSelectedType())) {
+            call.transformTo(newDocument);
+        } else {
+            if (!documentSelected.isEmpty()) {
+                return;
+            }
+            call.transformTo(
+                new LogicalProject(
+                    project.getCluster(),
+                    project.getTraitSet(),
+                    project.getHints(),
+                    newDocument,
+                    newProjectRexNodes,
+                    project.getRowType(),
+                    project.getVariablesSet()
+                )
+            );
+        }
+    }
+
+    @Override
+    public boolean autoPruneOld() {
+        return false;
+    }
+
+    @Value.Immutable
+    public interface Config extends RelRule.Config {
+        DingoDocumentProjectRule.Config DEFAULT = ImmutableDingoDocumentProjectRule.Config.builder()
+            .operandSupplier(b0 ->
+                b0.operand(LogicalProject.class).oneInput(b1 ->
+                    b1.operand(LogicalDingoDocument.class)
+                        .predicate(rel -> {
+                            if (rel.getRealSelection() == null) {
+                                return true;
+                            }
+                            DingoTable dingoTable = rel.getTable().unwrap(DingoTable.class);
+                            assert dingoTable != null;
+                            return rel.getRealSelection().size() == dingoTable.getTable().getColumns().size() + 1;
+                        } )
+                        .noInputs()
+                )
+            )
+            .description("DingoDocumentProjectRule")
+            .build();
+
+        @Override
+        default DingoDocumentProjectRule toRule() {
+            return new DingoDocumentProjectRule(this);
+        }
+    }
+}

--- a/dingo-calcite/src/main/java/io/dingodb/calcite/rule/DingoFunctionScanRule.java
+++ b/dingo-calcite/src/main/java/io/dingodb/calcite/rule/DingoFunctionScanRule.java
@@ -16,8 +16,10 @@
 
 package io.dingodb.calcite.rule;
 
+import io.dingodb.calcite.rel.DingoDocument;
 import io.dingodb.calcite.rel.DingoFunctionScan;
 import io.dingodb.calcite.rel.DingoVector;
+import io.dingodb.calcite.rel.LogicalDingoDocument;
 import io.dingodb.calcite.rel.LogicalDingoVector;
 import io.dingodb.calcite.traits.DingoConvention;
 import io.dingodb.calcite.traits.DingoRelStreaming;
@@ -66,7 +68,22 @@ public class DingoFunctionScanRule extends ConverterRule {
                 vector.getFilter(),
                 vector.hints
             );
-        } else if (rel instanceof DingoFunctionScan) {
+        } else if (rel instanceof LogicalDingoDocument && !(rel instanceof DingoDocument)) {
+            LogicalDingoDocument document = (LogicalDingoDocument) rel;
+            return new DingoDocument(
+                document.getCluster(),
+                traits,
+                document.getCall(),
+                document.getTable(),
+                document.getOperands(),
+                document.getIndexTableId(),
+                document.getIndexTable(),
+                document.getSelection(),
+                document.getFilter(),
+                document.hints
+            );
+        }
+        else if (rel instanceof DingoFunctionScan) {
             DingoFunctionScan scan = (DingoFunctionScan) rel;
             return new DingoFunctionScan(
                 scan.getCluster(),

--- a/dingo-calcite/src/main/java/io/dingodb/calcite/visitor/DingoExplainVisitor.java
+++ b/dingo-calcite/src/main/java/io/dingodb/calcite/visitor/DingoExplainVisitor.java
@@ -18,6 +18,7 @@ package io.dingodb.calcite.visitor;
 
 import io.dingodb.calcite.DingoTable;
 import io.dingodb.calcite.rel.DingoAggregate;
+import io.dingodb.calcite.rel.DingoDocument;
 import io.dingodb.calcite.rel.DingoExportData;
 import io.dingodb.calcite.rel.DingoFilter;
 import io.dingodb.calcite.rel.DingoFunctionScan;
@@ -37,6 +38,7 @@ import io.dingodb.calcite.rel.DingoTableScan;
 import io.dingodb.calcite.rel.DingoUnion;
 import io.dingodb.calcite.rel.DingoValues;
 import io.dingodb.calcite.rel.DingoVector;
+import io.dingodb.calcite.rel.DocumentStreamConvertor;
 import io.dingodb.calcite.rel.VectorStreamConvertor;
 import io.dingodb.calcite.rel.dingo.DingoHashJoin;
 import io.dingodb.calcite.rel.dingo.DingoIndexScanWithRelOp;
@@ -284,6 +286,22 @@ public class DingoExplainVisitor implements DingoRelVisitor<Explain> {
     }
 
     @Override
+    public Explain visit(@NonNull DingoDocument rel) {
+        String filter = "";
+        if (rel.getFilter() != null) {
+            filter = rel.getFilter().toString();
+        }
+        String tableNames = "";
+        if (rel.getIndexTable() != null) {
+            tableNames = rel.getIndexTable().getName();
+        }
+        return new Explain(
+            "dingDocument", rel.getRowCount(), "root",
+            tableNames, filter
+        );
+    }
+
+    @Override
     public Explain visit(@NonNull DingoGetVectorByDistance rel) {
         String accessObj = "";
         if (rel.getIndexTable() != null) {
@@ -299,6 +317,15 @@ public class DingoExplainVisitor implements DingoRelVisitor<Explain> {
             accessObj = rel.getIndexTableDefinition().getName();
         }
         return getCommonExplain(rel, "vectorStreamConverter", accessObj, "");
+    }
+
+    @Override
+    public Explain visit(@NonNull DocumentStreamConvertor rel) {
+        String accessObj = "";
+        if (rel.getIndexTableDefinition() != null) {
+            accessObj = rel.getIndexTableDefinition().getName();
+        }
+        return getCommonExplain(rel, "documentStreamConverter", accessObj, "");
     }
 
     @Override
@@ -457,5 +484,4 @@ public class DingoExplainVisitor implements DingoRelVisitor<Explain> {
         explain1.getChildren().add(explain);
         return explain1;
     }
-
 }

--- a/dingo-calcite/src/main/java/io/dingodb/calcite/visitor/DingoJobVisitor.java
+++ b/dingo-calcite/src/main/java/io/dingodb/calcite/visitor/DingoJobVisitor.java
@@ -17,6 +17,7 @@
 package io.dingodb.calcite.visitor;
 
 import io.dingodb.calcite.rel.DingoAggregate;
+import io.dingodb.calcite.rel.DingoDocument;
 import io.dingodb.calcite.rel.DingoExportData;
 import io.dingodb.calcite.rel.DingoFilter;
 import io.dingodb.calcite.rel.DingoFunctionScan;
@@ -35,6 +36,7 @@ import io.dingodb.calcite.rel.DingoTableScan;
 import io.dingodb.calcite.rel.DingoUnion;
 import io.dingodb.calcite.rel.DingoValues;
 import io.dingodb.calcite.rel.DingoVector;
+import io.dingodb.calcite.rel.DocumentStreamConvertor;
 import io.dingodb.calcite.rel.VectorStreamConvertor;
 import io.dingodb.calcite.rel.dingo.DingoHashJoin;
 import io.dingodb.calcite.rel.dingo.DingoIndexScanWithRelOp;
@@ -48,6 +50,8 @@ import io.dingodb.calcite.rel.dingo.IndexFullScan;
 import io.dingodb.calcite.rel.dingo.IndexRangeScan;
 import io.dingodb.calcite.visitor.function.DingoAggregateVisitFun;
 import io.dingodb.calcite.visitor.function.DingoCountDeleteVisitFun;
+import io.dingodb.calcite.visitor.function.DingoDocumentStreamingVisitFun;
+import io.dingodb.calcite.visitor.function.DingoDocumentVisitFun;
 import io.dingodb.calcite.visitor.function.DingoExportDataVisitFun;
 import io.dingodb.calcite.visitor.function.DingoFilterVisitFun;
 import io.dingodb.calcite.visitor.function.DingoFunctionScanVisitFun;
@@ -238,6 +242,11 @@ public class DingoJobVisitor implements DingoRelVisitor<Collection<Vertex>> {
         return DingoVectorVisitFun.visit(job, idGenerator, currentLocation, transaction, this, rel);
     }
 
+    @Override
+    public Collection<Vertex> visit(@NonNull DingoDocument rel) {
+        return DingoDocumentVisitFun.visit(job, idGenerator, currentLocation, transaction, this, rel);
+    }
+
 
     public Collection<Vertex> visit(@NonNull DingoGetVectorByDistance rel) {
         return DingoGetVectorByDistanceVisitFun.visit(job, idGenerator, currentLocation, this, rel);
@@ -246,6 +255,11 @@ public class DingoJobVisitor implements DingoRelVisitor<Collection<Vertex>> {
     @Override
     public Collection<Vertex> visit(@NonNull VectorStreamConvertor rel) {
         return DingoVectorStreamingVisitFun.visit(job, idGenerator, currentLocation, this, rel);
+    }
+
+    @Override
+    public Collection<Vertex> visit(@NonNull DocumentStreamConvertor rel) {
+        return DingoDocumentStreamingVisitFun.visit(job, idGenerator, currentLocation, this, rel);
     }
 
     @Override
@@ -291,6 +305,5 @@ public class DingoJobVisitor implements DingoRelVisitor<Collection<Vertex>> {
     public Collection<Vertex> visitDingoIndexScanWithRelOp(@NonNull DingoIndexScanWithRelOp rel) {
         return DingoIndexScanWithRelOpVisitFun.visit(job, idGenerator, currentLocation, transaction, this, rel);
     }
-
 
 }

--- a/dingo-calcite/src/main/java/io/dingodb/calcite/visitor/DingoRelVisitor.java
+++ b/dingo-calcite/src/main/java/io/dingodb/calcite/visitor/DingoRelVisitor.java
@@ -17,6 +17,7 @@
 package io.dingodb.calcite.visitor;
 
 import io.dingodb.calcite.rel.DingoAggregate;
+import io.dingodb.calcite.rel.DingoDocument;
 import io.dingodb.calcite.rel.DingoExportData;
 import io.dingodb.calcite.rel.DingoFilter;
 import io.dingodb.calcite.rel.DingoFunctionScan;
@@ -41,6 +42,7 @@ import io.dingodb.calcite.rel.DingoUnion;
 import io.dingodb.calcite.rel.DingoValues;
 import io.dingodb.calcite.rel.DingoVector;
 import io.dingodb.calcite.rel.VectorStreamConvertor;
+import io.dingodb.calcite.rel.DocumentStreamConvertor;
 import io.dingodb.calcite.rel.dingo.DingoReduceAggregate;
 import io.dingodb.calcite.rel.dingo.DingoRelOp;
 import io.dingodb.calcite.rel.dingo.DingoScanWithRelOp;
@@ -71,6 +73,8 @@ public interface DingoRelVisitor<T> {
 
     T visit(@NonNull DingoStreamingConverter rel);
 
+    T visit(@NonNull DocumentStreamConvertor rel);
+
     T visit(@NonNull DingoTableScan rel);
 
     T visit(@NonNull DingoUnion rel);
@@ -86,6 +90,8 @@ public interface DingoRelVisitor<T> {
     T visit(@NonNull DingoFunctionScan rel);
 
     T visit(@NonNull DingoVector rel);
+
+    T visit(@NonNull DingoDocument rel);
 
     T visit(@NonNull DingoGetVectorByDistance rel);
 

--- a/dingo-calcite/src/main/java/io/dingodb/calcite/visitor/function/DingoDocumentStreamingVisitFun.java
+++ b/dingo-calcite/src/main/java/io/dingodb/calcite/visitor/function/DingoDocumentStreamingVisitFun.java
@@ -1,0 +1,143 @@
+/*
+ * Copyright 2021 DataCanvas
+/*
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package io.dingodb.calcite.visitor.function;
+
+import io.dingodb.calcite.DingoRelOptTable;
+import io.dingodb.calcite.rel.DocumentStreamConvertor;
+import io.dingodb.calcite.traits.DingoRelPartition;
+import io.dingodb.calcite.traits.DingoRelPartitionByTable;
+import io.dingodb.calcite.utils.MetaServiceUtils;
+import io.dingodb.calcite.utils.TableInfo;
+import io.dingodb.calcite.visitor.DingoJobVisitor;
+import io.dingodb.common.CommonId;
+import io.dingodb.common.Location;
+import io.dingodb.common.partition.RangeDistribution;
+import io.dingodb.common.util.ByteArrayUtils;
+import io.dingodb.exec.base.IdGenerator;
+import io.dingodb.exec.base.Job;
+import io.dingodb.exec.base.OutputHint;
+import io.dingodb.exec.base.Task;
+import io.dingodb.exec.dag.Edge;
+import io.dingodb.exec.dag.Vertex;
+import io.dingodb.exec.operator.params.CoalesceParam;
+import io.dingodb.exec.operator.params.DocumentPartitionParam;
+import io.dingodb.meta.MetaService;
+
+import java.util.Collection;
+import java.util.LinkedHashMap;
+import java.util.LinkedList;
+import java.util.List;
+import java.util.Map;
+import java.util.NavigableMap;
+import java.util.Optional;
+import java.util.Set;
+
+import static io.dingodb.calcite.rel.DingoRel.dingo;
+import static io.dingodb.exec.utils.OperatorCodeUtils.COALESCE;
+import static io.dingodb.exec.utils.OperatorCodeUtils.DOCUMENT_PARTITION;
+
+public final class DingoDocumentStreamingVisitFun {
+
+    public static Collection<Vertex> visit(
+        Job job, IdGenerator idGenerator, Location currentLocation, DingoJobVisitor visitor, DocumentStreamConvertor rel
+    ) {
+        List<Vertex> outputs = new LinkedList<>();
+        Collection<Vertex> inputs = dingo(rel.getInput()).accept(visitor);
+        if (!rel.isNeedRoute()) {
+            outputs = DingoCoalesce.coalesce(idGenerator, inputs);
+            return outputs;
+        }
+
+        Set<DingoRelPartition> partitionSet = dingo(rel.getInput()).getStreaming().getPartitions();
+        // for loop inputs (part scan)
+        // document partitionOperator => loop document regions =>  Collection<Output>
+        Optional<DingoRelPartition> found = Optional.empty();
+        assert partitionSet != null;
+        for (DingoRelPartition dingoRelPartition : partitionSet) {
+            found = Optional.of(dingoRelPartition);
+            break;
+        }
+        DingoRelPartitionByTable partition = (DingoRelPartitionByTable) found.get();
+        DingoRelOptTable dingoRelOptTable = (DingoRelOptTable)partition.getTable();
+        final TableInfo tableInfo = MetaServiceUtils.getTableInfo(dingoRelOptTable);
+
+        String schemaName = dingoRelOptTable.getSchemaName();
+        MetaService metaService = MetaService.root().getSubMetaService(schemaName);
+        CommonId indexId = rel.getIndexId();
+        NavigableMap<ByteArrayUtils.ComparableByteArray, RangeDistribution> distributions
+            = metaService.getRangeDistribution(rel.getIndexId());
+
+        for (Vertex input : inputs) {
+            Task task = input.getTask();
+            DocumentPartitionParam param = new DocumentPartitionParam(
+                tableInfo.getId(),
+                distributions,
+                indexId,
+                rel.getDocumentIdIndex(),
+                rel.getIndexTableDefinition());
+            Vertex vertex = new Vertex(DOCUMENT_PARTITION, param);
+            vertex.setId(idGenerator.getOperatorId(task.getId()));
+            OutputHint hint = new OutputHint();
+            hint.setLocation(MetaService.root().currentLocation());
+            vertex.setHint(hint);
+            input.setPin(0);
+            Edge edge = new Edge(input, vertex);
+            input.addEdge(edge);
+            vertex.addIn(edge);
+            task.putVertex(vertex);
+            input.setPin(0);
+            outputs.add(vertex);
+        }
+        // coalesce
+        outputs = coalesce(idGenerator, outputs);
+        return outputs;
+    }
+
+    public static List<Vertex> coalesce(IdGenerator idGenerator, List<Vertex> inputList) {
+        Map<CommonId, List<Vertex>> inputsMap = new LinkedHashMap<>();
+        for (Vertex input : inputList) {
+            List<Vertex> list = inputsMap.computeIfAbsent(input.getHint().getPartId(), k -> new LinkedList<>());
+            list.add(input);
+        }
+        List<Vertex> outputs = new LinkedList<>();
+        for (Map.Entry<CommonId, List<Vertex>> entry : inputsMap.entrySet()) {
+            List<Vertex> list = entry.getValue();
+            int size = list.size();
+            if (list.size() <= 1) {
+                // Need no coalescing.
+                outputs.addAll(list);
+            } else {
+                Vertex one = list.get(0);
+                Task task = one.getTask();
+                Vertex vertex = new Vertex(COALESCE, new CoalesceParam(size));
+                vertex.setId(idGenerator.getOperatorId(task.getId()));
+                task.putVertex(vertex);
+                int i = 0;
+                for (Vertex input : list) {
+                    input.addEdge(new Edge(input, vertex));
+                    input.setPin(i);
+                    ++i;
+                }
+                vertex.addIn(new Edge(one, vertex));
+                vertex.copyHint(one);
+                outputs.add(vertex);
+            }
+        }
+        return outputs;
+    }
+
+}

--- a/dingo-calcite/src/main/java/io/dingodb/calcite/visitor/function/DingoDocumentVisitFun.java
+++ b/dingo-calcite/src/main/java/io/dingodb/calcite/visitor/function/DingoDocumentVisitFun.java
@@ -1,0 +1,362 @@
+/*
+ * Copyright 2021 DataCanvas
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package io.dingodb.calcite.visitor.function;
+
+import io.dingodb.calcite.DingoRelOptTable;
+import io.dingodb.calcite.DingoTable;
+import io.dingodb.calcite.rel.DingoDocument;
+import io.dingodb.calcite.utils.SqlExprUtils;
+import io.dingodb.calcite.utils.VisitUtils;
+import io.dingodb.calcite.visitor.DingoJobVisitor;
+import io.dingodb.calcite.visitor.RexConverter;
+import io.dingodb.common.CommonId;
+import io.dingodb.common.Location;
+import io.dingodb.common.partition.RangeDistribution;
+import io.dingodb.common.type.ListType;
+import io.dingodb.common.type.TupleMapping;
+import io.dingodb.common.type.scalar.BooleanType;
+import io.dingodb.common.type.scalar.DecimalType;
+import io.dingodb.common.type.scalar.DoubleType;
+import io.dingodb.common.type.scalar.FloatType;
+import io.dingodb.common.type.scalar.IntegerType;
+import io.dingodb.common.type.scalar.LongType;
+import io.dingodb.common.type.scalar.StringType;
+import io.dingodb.common.util.ByteArrayUtils.ComparableByteArray;
+import io.dingodb.common.util.Optional;
+import io.dingodb.exec.base.IdGenerator;
+import io.dingodb.exec.base.Job;
+import io.dingodb.exec.base.OutputHint;
+import io.dingodb.exec.base.Task;
+import io.dingodb.exec.dag.Vertex;
+import io.dingodb.exec.expr.SqlExpr;
+import io.dingodb.exec.operator.params.PartDocumentParam;
+import io.dingodb.exec.operator.params.TxnPartDocumentParam;
+import io.dingodb.exec.transaction.base.ITransaction;
+import io.dingodb.expr.rel.RelOp;
+import io.dingodb.expr.rel.op.RelOpBuilder;
+import io.dingodb.expr.runtime.expr.Expr;
+import io.dingodb.meta.MetaService;
+import io.dingodb.meta.entity.Column;
+import io.dingodb.meta.entity.IndexTable;
+import io.dingodb.meta.entity.Table;
+import lombok.extern.slf4j.Slf4j;
+import org.apache.calcite.rex.RexCall;
+import org.apache.calcite.rex.RexInputRef;
+import org.apache.calcite.rex.RexLiteral;
+import org.apache.calcite.rex.RexNode;
+import org.apache.calcite.rex.RexUtil;
+import org.apache.calcite.rex.RexVisitorImpl;
+import org.apache.calcite.sql.SqlBasicCall;
+import org.apache.calcite.sql.SqlCharStringLiteral;
+import org.apache.calcite.sql.SqlIdentifier;
+import org.apache.calcite.sql.SqlLiteral;
+import org.apache.calcite.sql.SqlNode;
+import org.apache.calcite.sql.SqlNumericLiteral;
+import org.apache.calcite.sql.fun.SqlArrayValueConstructor;
+import org.apache.calcite.util.mapping.Mapping;
+import org.apache.calcite.util.mapping.Mappings;
+import org.checkerframework.checker.nullness.qual.NonNull;
+
+import java.util.ArrayList;
+import java.util.Collection;
+import java.util.HashMap;
+import java.util.List;
+import java.util.Map;
+import java.util.NavigableMap;
+import java.util.Objects;
+import java.util.concurrent.atomic.AtomicInteger;
+import java.util.stream.Collectors;
+
+import static io.dingodb.common.util.Utils.isNeedLookUp;
+import static io.dingodb.exec.utils.OperatorCodeUtils.PART_DOCUMENT;
+import static io.dingodb.exec.utils.OperatorCodeUtils.TXN_PART_DOCUMENT;
+
+@Slf4j
+public final class DingoDocumentVisitFun {
+
+    // tmp use
+    public static List<Object> pushDownSchemaList = new ArrayList<>();
+
+    static {
+        pushDownSchemaList.add(IntegerType.class);
+        pushDownSchemaList.add(LongType.class);
+        pushDownSchemaList.add(BooleanType.class);
+        pushDownSchemaList.add(FloatType.class);
+        pushDownSchemaList.add(DoubleType.class);
+        pushDownSchemaList.add(DecimalType.class);
+        pushDownSchemaList.add(StringType.class);
+    }
+
+    private DingoDocumentVisitFun() {
+
+    }
+
+    public static Collection<Vertex> visit(
+        Job job, IdGenerator idGenerator, Location currentLocation,
+        ITransaction transaction, DingoJobVisitor visitor, DingoDocument rel
+    ) {
+        DingoRelOptTable relTable = rel.getTable();
+        DingoTable dingoTable = relTable.unwrap(DingoTable.class);
+
+        MetaService metaService = MetaService.root().getSubMetaService(relTable.getSchemaName());
+        assert dingoTable != null;
+        CommonId tableId = dingoTable.getTableId();
+        Table td = dingoTable.getTable();
+
+        NavigableMap<ComparableByteArray, RangeDistribution> ranges = metaService.getRangeDistribution(tableId);
+        List<Object> operandsList = rel.getOperands();
+        String queryString = Objects.requireNonNull((SqlCharStringLiteral) operandsList.get(2)).getStringValue();
+
+        if (!(operandsList.get(3) instanceof SqlNumericLiteral)) {
+            throw new IllegalArgumentException("Top n not number.");
+        }
+
+        int topN = ((Number) Objects.requireNonNull(((SqlNumericLiteral) operandsList.get(3)).getValue())).intValue();
+
+        List<Vertex> outputs = new ArrayList<>();
+
+        IndexTable indexTable = (IndexTable) rel.getIndexTable();
+        boolean pushDown = false;
+        RexNode rexFilter = rel.getFilter();
+        TupleMapping resultSelection = rel.getSelection();
+
+        List<Column> columnNames = indexTable.getColumns();
+        List<Integer> priKeySecList = dingoTable.getTable()
+            .columns.stream()
+            .filter(Column::isPrimary)
+            .map(dingoTable.getTable().columns::indexOf)
+            .collect(Collectors.toList());
+        int priKeyCount = priKeySecList.size();
+        // document index cols in pri table selection
+        List<Integer> indexLookupSelectionList = columnNames
+            .stream()
+            .filter(col -> !col.isPrimary() && col.getState() == 1)
+            .map(dingoTable.getTable().columns::indexOf)
+            .collect(Collectors.toList());
+        priKeySecList.addAll(indexLookupSelectionList);
+        boolean isLookUp = isNeedLookUp(
+            resultSelection,
+            TupleMapping.of(priKeySecList),
+            dingoTable.getTable().columns.size()
+        );
+        boolean isTxn = dingoTable.getTable().getEngine().contains("TXN");
+        TupleMapping pushDownSelection;
+        if (pushDown && isTxn) {
+            List<Integer> secList = new ArrayList<>();
+            for (int i = 0; i < priKeyCount; i ++) {
+                secList.add(i);
+            }
+            AtomicInteger ix = new AtomicInteger(priKeyCount);
+            List<Integer> indexList = indexTable
+                .getColumns()
+                .stream()
+                .filter(col -> col.getState() == 1 && !col.isPrimary())
+                .map(col -> ix.getAndIncrement())
+                .collect(Collectors.toList());
+            secList.addAll(indexList);
+            pushDownSelection = TupleMapping.of(secList);
+
+            Mapping mapping = Mappings.target(priKeySecList, dingoTable.getTable().getColumns().size());
+            rexFilter = RexUtil.apply(mapping, rexFilter);
+        } else {
+            TupleMapping realSelection = rel.getRealSelection();
+            List<Integer> selectedColumns = realSelection.stream().boxed().collect(Collectors.toList());
+            Mapping mapping = Mappings.target(selectedColumns, dingoTable.getTable().getColumns().size() + 1);
+            rexFilter = (rexFilter != null) ? RexUtil.apply(mapping, rexFilter) : null;
+            pushDownSelection = resultSelection;
+        }
+        SqlExpr filter = null;
+        if (rexFilter != null) {
+            filter = SqlExprUtils.toSqlExpr(rexFilter);
+        }
+        long scanTs = VisitUtils.getScanTs(transaction, visitor.getKind());
+        // Get query additional parameters
+//        Map<String, Object> parameterMap = getParameterMap(operandsList);
+        // Get all index table distributions
+        NavigableMap<ComparableByteArray, RangeDistribution> indexRanges =
+            metaService.getRangeDistribution(rel.getIndexTableId());
+
+        // Create tasks based on partitions
+        for (RangeDistribution rangeDistribution : indexRanges.values()) {
+            Vertex vertex;
+            if (transaction == null) {
+                PartDocumentParam param = new PartDocumentParam(
+                    tableId,
+                    rangeDistribution.id(),
+                    rel.tupleType(),
+                    td.keyMapping(),
+                    Optional.mapOrNull(filter, SqlExpr::copy),
+                    rel.getSelection(),
+                    td,
+                    ranges,
+                    rel.getIndexTableId(),
+                    queryString,
+                    topN
+                );
+                vertex = new Vertex(PART_DOCUMENT, param);
+            } else {
+
+                RelOp relOp = null;
+                if (rexFilter != null) {
+                    Expr expr = RexConverter.convert(rexFilter);
+                    relOp = RelOpBuilder.builder()
+                        .filter(expr)
+                        .build();
+                }
+                TxnPartDocumentParam param = new TxnPartDocumentParam(
+                    rangeDistribution.id(),
+                    Optional.mapOrNull(filter, SqlExpr::copy),
+                    pushDownSelection,
+                    rel.tupleType(),
+                    td,
+                    ranges,
+                    queryString,
+                    topN,
+                    indexTable,
+                    relOp,
+                    pushDown,
+                    isLookUp,
+                    scanTs,
+                    transaction.getIsolationLevel(),
+                    transaction.getLockTimeOut(),
+                    resultSelection
+                );
+                vertex = new Vertex(TXN_PART_DOCUMENT, param);
+            }
+            Task task = job.getOrCreate(currentLocation, idGenerator);
+            OutputHint hint = new OutputHint();
+            hint.setPartId(rangeDistribution.id());
+            vertex.setHint(hint);
+            vertex.setId(idGenerator.getOperatorId(task.getId()));
+            task.putVertex(vertex);
+            outputs.add(vertex);
+        }
+        visitor.setScan(true);
+        return outputs;
+    }
+
+    public static String[] getDocumentString(List<Object> operandsList) {
+        String[] stringArray = null;
+        Object call = operandsList.get(2);
+        if (call instanceof RexCall) {
+            RexCall rexCall = (RexCall) call;
+            int documentCount = rexCall.getOperands().size();
+            for (int i = 0; i < documentCount; i++) {
+                RexLiteral literal = (RexLiteral) rexCall.getOperands().get(i);
+                stringArray[i] = literal.getValueAs(String.class);
+            }
+            return stringArray;
+        }
+        SqlBasicCall basicCall = (SqlBasicCall) operandsList.get(2);
+        if (basicCall.getOperator() instanceof SqlArrayValueConstructor) {
+            List<SqlNode> operands = basicCall.getOperandList();
+            for (int i = 0; i < operands.size(); i++) {
+                stringArray[i] = Objects.requireNonNull(((SqlNumericLiteral) operands.get(i)).getValue())
+                .toString();
+            }
+        } else {
+            List<SqlNode> sqlNodes = basicCall.getOperandList();
+            if (sqlNodes.size() < 2) {
+                throw new RuntimeException("document load param error");
+            }
+            List<Object> paramList = sqlNodes.stream().map(e -> {
+                if (e instanceof SqlLiteral) {
+                    return ((SqlLiteral)e).getValue();
+                } else if (e instanceof SqlIdentifier) {
+                    return ((SqlIdentifier)e).getSimple();
+                } else {
+                    return e.toString();
+                }
+            }).collect(Collectors.toList());
+            if (paramList.get(1) == null || paramList.get(0) == null) {
+                throw new RuntimeException("document load param error");
+            }
+            String param = paramList.get(1).toString();
+            if (param.contains("'")) {
+                param = param.replace("'", "");
+            }
+        }
+        /* keyword can be null */
+        return stringArray;
+    }
+
+    private static Map<String, Object> getParameterMap(List<Object> operandsList) {
+        Map<String, Object> parameterMap = new HashMap<>();
+        if (operandsList.size() >= 5) {
+            SqlNode sqlNode = (SqlNode) operandsList.get(4);
+            if (sqlNode instanceof SqlBasicCall) {
+                SqlBasicCall sqlBasicCall = (SqlBasicCall) operandsList.get(4);
+                if (sqlBasicCall.getOperator().getName().equals("MAP")) {
+                    List<SqlNode> operandList = sqlBasicCall.getOperandList();
+                    String currentName = "";
+                    for (int i = 0; i < operandList.size(); i++) {
+                        if ((i % 2 == 0) && operandList.get(i) instanceof SqlIdentifier) {
+                            currentName = ((SqlIdentifier) operandList.get(i)).getSimple();
+                        } else {
+                            SqlNode node = operandList.get(i);
+                            if (!currentName.equals("") && node instanceof SqlNumericLiteral) {
+                                parameterMap.put(currentName, ((SqlNumericLiteral)node).getValue());
+                            }
+                        }
+                    }
+                }
+            }
+        }
+
+        return parameterMap;
+    }
+
+    private static boolean pushDown(RexNode filter, Table table, IndexTable indexTable) {
+        if (filter == null) {
+            return false;
+        }
+        List<Integer> inputRefList = new ArrayList<>();
+        RexVisitorImpl<Void> visitor = new RexVisitorImpl<Void>(true) {
+            @Override
+            public Void visitInputRef(@NonNull RexInputRef inputRef) {
+                if (!inputRefList.contains(inputRef.getIndex())) {
+                    inputRefList.add(inputRef.getIndex());
+                }
+                return super.visitInputRef(inputRef);
+            }
+        };
+        filter.accept(visitor);
+        List<Column> selectionColList = inputRefList.stream()
+            .filter(i -> i < table.columns.size())
+            .map(i -> table.getColumns().get(i))
+            .filter(col -> !col.isPrimary())
+            .collect(Collectors.toList());
+        if (selectionColList.isEmpty()) {
+            return false;
+        }
+        boolean recognizableTypes = selectionColList.stream()
+            .allMatch(column -> pushDownSchemaList.contains(column.type.getClass()));
+        if (!recognizableTypes) {
+            return false;
+        }
+
+        // document index only with field can push down
+        List<Column> filterIndexCols = indexTable.getColumns().stream()
+            .filter(col -> !col.isPrimary() && !(col.getType() instanceof ListType))
+            .collect(Collectors.toList());
+        java.util.Optional<Column> optional = selectionColList.stream()
+            .filter(column -> !filterIndexCols.contains(column))
+            .findFirst();
+        return !optional.isPresent();
+    }
+
+}

--- a/dingo-calcite/src/main/java/org/apache/calcite/sql2rel/SqlDocumentOperator.java
+++ b/dingo-calcite/src/main/java/org/apache/calcite/sql2rel/SqlDocumentOperator.java
@@ -38,7 +38,7 @@ import java.util.Collections;
 public class SqlDocumentOperator extends SqlFunction implements SqlTableFunction {
 
     public static void register(DingoParserContext context) {
-        StandardConvertletTable.INSTANCE.registerOp(SqlUserDefinedOperators.TEXT,
+        StandardConvertletTable.INSTANCE.registerOp(SqlUserDefinedOperators.TEXT_SEARCH,
             (cx, call) -> {
                 RexBuilder rexBuilder = cx.getRexBuilder();
                 TableFunctionNamespace namespace = (TableFunctionNamespace) cx.getValidator().getNamespace(call);

--- a/dingo-calcite/src/main/java/org/apache/calcite/sql2rel/SqlDocumentOperator.java
+++ b/dingo-calcite/src/main/java/org/apache/calcite/sql2rel/SqlDocumentOperator.java
@@ -38,7 +38,7 @@ import java.util.Collections;
 public class SqlDocumentOperator extends SqlFunction implements SqlTableFunction {
 
     public static void register(DingoParserContext context) {
-        StandardConvertletTable.INSTANCE.registerOp(SqlUserDefinedOperators.DOCUMENT,
+        StandardConvertletTable.INSTANCE.registerOp(SqlUserDefinedOperators.TEXT,
             (cx, call) -> {
                 RexBuilder rexBuilder = cx.getRexBuilder();
                 TableFunctionNamespace namespace = (TableFunctionNamespace) cx.getValidator().getNamespace(call);
@@ -46,6 +46,11 @@ public class SqlDocumentOperator extends SqlFunction implements SqlTableFunction
             });
     }
 
+    /**
+     * Creates a SqlDocumentOperator.
+     *
+     * @param name        Operator name
+     */
     public SqlDocumentOperator(String name, SqlKind kind) {
         super(
             name,

--- a/dingo-driver/host/src/main/java/io/dingodb/driver/DingoDriverParser.java
+++ b/dingo-driver/host/src/main/java/io/dingodb/driver/DingoDriverParser.java
@@ -34,6 +34,7 @@ import io.dingodb.calcite.operation.QueryOperation;
 import io.dingodb.calcite.operation.ShowProcessListOperation;
 import io.dingodb.calcite.rel.AutoIncrementShuttle;
 import io.dingodb.calcite.rel.DingoBasicCall;
+import io.dingodb.calcite.rel.DingoDocument;
 import io.dingodb.calcite.rel.DingoVector;
 import io.dingodb.calcite.type.converter.DefinitionMapper;
 import io.dingodb.calcite.utils.RelNodeCache;
@@ -683,18 +684,18 @@ public final class DingoDriverParser extends DingoParser {
             RelOptTable table = input.getTable();
             tables.add(table);
         }
-        RelOptTable vectorTable = findVectorFunction(relNode);
-        if (vectorTable != null) {
-            tables.add(vectorTable);
+        RelOptTable functionTable = findUserDefindedFunction(relNode);
+        if (functionTable != null) {
+            tables.add(functionTable);
         }
         return tables;
     }
 
-    private static RelOptTable findVectorFunction(RelNode relNode) {
+    private static RelOptTable findUserDefindedFunction(RelNode relNode) {
         RelShuttleImpl relShuttle = new RelShuttleImpl() {
             @Override
             public RelNode visit(RelNode other) {
-                if (other instanceof DingoVector) {
+                if (other instanceof DingoVector || other instanceof  DingoDocument) {
                     return other;
                 }
                 if (!other.getInputs().isEmpty()) {
@@ -718,6 +719,8 @@ public final class DingoDriverParser extends DingoParser {
                 RelNode child2 = child.accept(this);
                 if (child2 instanceof DingoVector) {
                     return child2;
+                } else if (child2 instanceof DingoDocument) {
+                    return child2;
                 }
                 return null;
             }
@@ -726,6 +729,9 @@ public final class DingoDriverParser extends DingoParser {
         if (relNode1 instanceof DingoVector) {
             DingoVector vector = (DingoVector) relNode1;
             return vector.getTable();
+        } else if(relNode1 instanceof DingoDocument){
+            DingoDocument document = (DingoDocument) relNode1;
+            return document.getTable();
         }
         return null;
     }

--- a/dingo-exec/src/main/java/io/dingodb/exec/OperatorFactory.java
+++ b/dingo-exec/src/main/java/io/dingodb/exec/OperatorFactory.java
@@ -44,6 +44,7 @@ import io.dingodb.exec.operator.PartRangeDeleteOperator;
 import io.dingodb.exec.operator.PartRangeScanOperator;
 import io.dingodb.exec.operator.PartUpdateOperator;
 import io.dingodb.exec.operator.PartVectorOperator;
+import io.dingodb.exec.operator.PartDocumentOperator;
 import io.dingodb.exec.operator.PartitionOperator;
 import io.dingodb.exec.operator.PessimisticLockDeleteOperator;
 import io.dingodb.exec.operator.PessimisticLockInsertOperator;
@@ -67,6 +68,7 @@ import io.dingodb.exec.operator.TxnGetByKeysOperator;
 import io.dingodb.exec.operator.TxnIndexRangeScanOperator;
 import io.dingodb.exec.operator.TxnLikeScanOperator;
 import io.dingodb.exec.operator.TxnPartDeleteOperator;
+import io.dingodb.exec.operator.TxnPartDocumentOperator;
 import io.dingodb.exec.operator.TxnPartInsertOperator;
 import io.dingodb.exec.operator.TxnPartRangeDeleteOperator;
 import io.dingodb.exec.operator.TxnPartRangeScanOperator;
@@ -114,6 +116,7 @@ import static io.dingodb.exec.utils.OperatorCodeUtils.OPTIMISTIC_ROLL_BACK;
 import static io.dingodb.exec.utils.OperatorCodeUtils.PARTITION;
 import static io.dingodb.exec.utils.OperatorCodeUtils.PART_COUNT;
 import static io.dingodb.exec.utils.OperatorCodeUtils.PART_DELETE;
+import static io.dingodb.exec.utils.OperatorCodeUtils.PART_DOCUMENT;
 import static io.dingodb.exec.utils.OperatorCodeUtils.PART_INSERT;
 import static io.dingodb.exec.utils.OperatorCodeUtils.PART_RANGE_DELETE;
 import static io.dingodb.exec.utils.OperatorCodeUtils.PART_RANGE_SCAN;
@@ -147,6 +150,7 @@ import static io.dingodb.exec.utils.OperatorCodeUtils.TXN_GET_BY_KEYS;
 import static io.dingodb.exec.utils.OperatorCodeUtils.TXN_INDEX_RANGE_SCAN;
 import static io.dingodb.exec.utils.OperatorCodeUtils.TXN_LIKE_SCAN;
 import static io.dingodb.exec.utils.OperatorCodeUtils.TXN_PART_DELETE;
+import static io.dingodb.exec.utils.OperatorCodeUtils.TXN_PART_DOCUMENT;
 import static io.dingodb.exec.utils.OperatorCodeUtils.TXN_PART_INSERT;
 import static io.dingodb.exec.utils.OperatorCodeUtils.TXN_PART_RANGE_DELETE;
 import static io.dingodb.exec.utils.OperatorCodeUtils.TXN_PART_RANGE_SCAN;
@@ -184,6 +188,7 @@ public final class OperatorFactory {
         OPERATORS.put(PART_RANGE_SCAN, PartRangeScanOperator.INSTANCE);
         OPERATORS.put(PART_UPDATE, PartUpdateOperator.INSTANCE);
         OPERATORS.put(PART_VECTOR, PartVectorOperator.INSTANCE);
+        OPERATORS.put(PART_DOCUMENT, PartDocumentOperator.INSTANCE);
         OPERATORS.put(PROJECT, ProjectOperator.INSTANCE);
         OPERATORS.put(RECEIVE, ReceiveOperator.INSTANCE);
         OPERATORS.put(REDUCE, ReduceOperator.INSTANCE);
@@ -232,6 +237,7 @@ public final class OperatorFactory {
         OPERATORS.put(TXN_INDEX_RANGE_SCAN, TxnIndexRangeScanOperator.INSTANCE);
         OPERATORS.put(PESSIMISTIC_LOCK, PessimisticLockOperator.INSTANCE);
         OPERATORS.put(PESSIMISTIC_RESIDUAL_LOCK, PessimisticResidualLockOperator.INSTANCE);
+        OPERATORS.put(TXN_PART_DOCUMENT, TxnPartDocumentOperator.INSTANCE);
     }
 
     private OperatorFactory() {

--- a/dingo-exec/src/main/java/io/dingodb/exec/operator/PartDocumentOperator.java
+++ b/dingo-exec/src/main/java/io/dingodb/exec/operator/PartDocumentOperator.java
@@ -1,0 +1,46 @@
+/*
+ * Copyright 2021 DataCanvas
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package io.dingodb.exec.operator;
+
+import io.dingodb.exec.dag.Vertex;
+import io.dingodb.exec.operator.params.PartDocumentParam;
+import io.dingodb.store.api.StoreInstance;
+import io.dingodb.store.api.StoreService;
+import lombok.extern.slf4j.Slf4j;
+import org.checkerframework.checker.nullness.qual.NonNull;
+
+import java.util.ArrayList;
+import java.util.Iterator;
+import java.util.List;
+
+@Slf4j
+public final class PartDocumentOperator extends FilterProjectSourceOperator {
+    public static final PartDocumentOperator INSTANCE = new PartDocumentOperator();
+
+    private PartDocumentOperator() {
+    }
+
+    @Override
+    protected @NonNull Iterator<Object[]> createSourceIterator(Vertex vertex) {
+        PartDocumentParam param = vertex.getParam();
+        StoreInstance instance = StoreService.getDefault().getInstance(param.getTableId(), param.getPartId());
+        //TODO
+        List<Object[]> results = new ArrayList<>();
+        return results.iterator();
+    }
+
+}

--- a/dingo-exec/src/main/java/io/dingodb/exec/operator/TxnPartDocumentOperator.java
+++ b/dingo-exec/src/main/java/io/dingodb/exec/operator/TxnPartDocumentOperator.java
@@ -1,0 +1,109 @@
+/*
+ * Copyright 2021 DataCanvas
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package io.dingodb.exec.operator;
+
+import io.dingodb.common.CommonId;
+import io.dingodb.common.profile.OperatorProfile;
+import io.dingodb.common.store.KeyValue;
+import io.dingodb.common.type.ListType;
+import io.dingodb.common.type.TupleMapping;
+import io.dingodb.common.util.Optional;
+import io.dingodb.exec.Services;
+import io.dingodb.exec.dag.Vertex;
+import io.dingodb.exec.operator.params.TxnPartDocumentParam;
+import io.dingodb.meta.entity.Column;
+import io.dingodb.meta.entity.IndexTable;
+import io.dingodb.meta.entity.Table;
+import io.dingodb.store.api.StoreInstance;
+import io.dingodb.store.api.transaction.data.DocumentSearchParameter;
+import io.dingodb.store.api.transaction.data.DocumentValue;
+import io.dingodb.store.api.transaction.data.DocumentWithId;
+import io.dingodb.store.api.transaction.data.DocumentWithScore;
+import io.dingodb.store.api.transaction.data.ScalarField;
+import lombok.extern.slf4j.Slf4j;
+import org.checkerframework.checker.nullness.qual.NonNull;
+
+import java.util.ArrayList;
+import java.util.HashMap;
+import java.util.Iterator;
+import java.util.List;
+import java.util.Map;
+import java.util.Set;
+
+@Slf4j
+public class TxnPartDocumentOperator extends FilterProjectSourceOperator {
+
+    public static final TxnPartDocumentOperator INSTANCE = new TxnPartDocumentOperator();
+
+    @Override
+    protected @NonNull Iterator<Object[]> createSourceIterator(Vertex vertex) {
+        TxnPartDocumentParam param = vertex.getParam();
+        OperatorProfile profile = param.getProfile("partDocument");
+        long start = System.currentTimeMillis();
+        StoreInstance instance = Services.KV_STORE.getInstance(param.getTableId(), param.getPartId());
+        DocumentSearchParameter documentSearchParameter = DocumentSearchParameter.builder()
+            .topN(param.getTopN())
+            .queryString(param.getQueryString())
+            .build();
+        List<DocumentWithScore> documentWithScores = instance.documentSearch(
+            param.getScanTs(),
+            param.getIndexId(),
+            documentSearchParameter);
+        List<Object[]> results = new ArrayList<>();
+        IndexTable indexTable =param.getIndexTable();
+        List<Column>  columns = param.getTable().getColumns();
+            for (DocumentWithScore document: documentWithScores) {
+                Object[] priTuples = new Object[param.getTable().columns.size() + 1];
+                DocumentWithId documentWithId = document.getDocumentWithId();
+                Map<String, DocumentValue> documentData = documentWithId.getDocument().getDocumentData();
+                Set<Map.Entry<String, DocumentValue>> entries = documentData.entrySet();
+                for (Map.Entry<String, DocumentValue> entry : entries) {
+                    String key = entry.getKey();
+                    DocumentValue value = entry.getValue();
+                    ScalarField fieldValue = value.getFieldValue();
+                    int idx = 0;
+                    for(int i = 0; i < columns.size(); i++){
+                        if(columns.get(i).getName().equals(key)){
+                            idx = i;
+                            break;
+                        }
+                    }
+                    priTuples[idx] = fieldValue.getData();
+                }
+
+                float score = document.getScore();
+                priTuples[priTuples.length -1] = score;
+                results.add(priTuples);
+            }
+
+        profile.incrTime(start);
+        return results.iterator();
+    }
+
+//    private static Map<Integer, Integer> getDocPriIdxMapping(TxnPartDocumentParam param) {
+//        int docColSize = param.getTableDataColList().size();
+//        Map<Integer, Integer> mapping = new HashMap<>();
+//        for (int i = 0; i < docColSize; i ++) {
+//            Column column = param.getTableDataColList().get(i);
+//            if (!column.isPrimary()) {
+//                int ix1 = param.getTable().getColumns().indexOf(column);
+//                mapping.put(i, ix1);
+//            }
+//        }
+//        return mapping;
+//    }
+}

--- a/dingo-exec/src/main/java/io/dingodb/exec/operator/params/AbstractParams.java
+++ b/dingo-exec/src/main/java/io/dingodb/exec/operator/params/AbstractParams.java
@@ -112,7 +112,8 @@ import lombok.Setter;
     @JsonSubTypes.Type(TxnGetByIndexParam.class),
     @JsonSubTypes.Type(PessimisticLockParam.class),
     @JsonSubTypes.Type(PessimisticResidualLockParam.class),
-    @JsonSubTypes.Type(ScanCacheResidualLockParam.class)
+    @JsonSubTypes.Type(ScanCacheResidualLockParam.class),
+    @JsonSubTypes.Type(TxnPartDocumentParam.class)
 })
 @JsonInclude(JsonInclude.Include.NON_NULL)
 public abstract class AbstractParams {

--- a/dingo-exec/src/main/java/io/dingodb/exec/operator/params/DocumentPartitionParam.java
+++ b/dingo-exec/src/main/java/io/dingodb/exec/operator/params/DocumentPartitionParam.java
@@ -1,0 +1,74 @@
+/*
+ * Copyright 2021 DataCanvas
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package io.dingodb.exec.operator.params;
+
+import com.fasterxml.jackson.annotation.JsonProperty;
+import com.fasterxml.jackson.annotation.JsonPropertyOrder;
+import com.fasterxml.jackson.annotation.JsonTypeName;
+import com.fasterxml.jackson.databind.annotation.JsonDeserialize;
+import com.fasterxml.jackson.databind.annotation.JsonSerialize;
+import io.dingodb.codec.CodecService;
+import io.dingodb.codec.KeyValueCodec;
+import io.dingodb.common.CommonId;
+import io.dingodb.common.partition.RangeDistribution;
+import io.dingodb.common.type.DingoType;
+import io.dingodb.common.type.DingoTypeFactory;
+import io.dingodb.common.type.TupleMapping;
+import io.dingodb.common.type.TupleType;
+import io.dingodb.common.type.scalar.LongType;
+import io.dingodb.common.util.ByteArrayUtils;
+import io.dingodb.meta.entity.Table;
+import lombok.Getter;
+import lombok.Setter;
+
+import java.util.Map;
+import java.util.NavigableMap;
+
+@Getter
+@JsonTypeName("documentPartition")
+@JsonPropertyOrder({"tableId"})
+public class DocumentPartitionParam extends AbstractParams {
+
+    @JsonProperty("tableId")
+    @JsonSerialize(using = CommonId.JacksonSerializer.class)
+    @JsonDeserialize(using = CommonId.JacksonDeserializer.class)
+    private final CommonId tableId;
+    private final NavigableMap<ByteArrayUtils.ComparableByteArray, RangeDistribution> distributions;
+    @Setter
+    private Map<CommonId, Integer> partIndices;
+    private Integer index;
+    private final KeyValueCodec codec;
+    private final Table table;
+
+    public DocumentPartitionParam(
+        CommonId tableId,
+        NavigableMap<ByteArrayUtils.ComparableByteArray, RangeDistribution> distributions,
+        CommonId indexId,
+        Integer index,
+        Table table
+    ) {
+        this.tableId = tableId;
+        this.distributions = distributions;
+        this.index = index;
+        DingoType dingoType = new LongType(false);
+        TupleType tupleType = DingoTypeFactory.tuple(new DingoType[]{dingoType});
+        TupleMapping outputKeyMapping = TupleMapping.of(new int[] {0});
+        this.codec = CodecService.getDefault().createKeyValueCodec(indexId, tupleType, outputKeyMapping);
+        this.table = table;
+    }
+
+}

--- a/dingo-exec/src/main/java/io/dingodb/exec/operator/params/PartDocumentParam.java
+++ b/dingo-exec/src/main/java/io/dingodb/exec/operator/params/PartDocumentParam.java
@@ -1,0 +1,70 @@
+/*
+ * Copyright 2021 DataCanvas
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package io.dingodb.exec.operator.params;
+
+import com.fasterxml.jackson.annotation.JsonPropertyOrder;
+import com.fasterxml.jackson.annotation.JsonTypeName;
+import io.dingodb.codec.CodecService;
+import io.dingodb.codec.KeyValueCodec;
+import io.dingodb.common.CommonId;
+import io.dingodb.common.partition.RangeDistribution;
+import io.dingodb.common.type.DingoType;
+import io.dingodb.common.type.TupleMapping;
+import io.dingodb.common.util.ByteArrayUtils;
+import io.dingodb.exec.expr.SqlExpr;
+import io.dingodb.meta.entity.Table;
+import lombok.Getter;
+
+import java.util.Map;
+import java.util.NavigableMap;
+
+@Getter
+@JsonTypeName("partDocument")
+@JsonPropertyOrder({
+    "tableId", "part", "schema", "schemaVersion", "keyMapping", "filter", "selection", "indexId", "indexRegionId"
+})
+public class PartDocumentParam extends FilterProjectSourceParam {
+
+    private final KeyValueCodec codec;
+    private final Table table;
+    private final NavigableMap<ByteArrayUtils.ComparableByteArray, RangeDistribution> distributions;
+    private final CommonId indexId;
+    private final String queryString;
+    private final int topN;
+
+    public PartDocumentParam(
+        CommonId tableId,
+        CommonId partId,
+        DingoType schema,
+        TupleMapping keyMapping,
+        SqlExpr filter,
+        TupleMapping selection,
+        Table table,
+        NavigableMap<ByteArrayUtils.ComparableByteArray, RangeDistribution> distributions,
+        CommonId indexId,
+        String queryString,
+        int topN
+    ) {
+        super(tableId, partId, schema, table.version, filter, selection, keyMapping);
+        this.codec = CodecService.getDefault().createKeyValueCodec(table.version, table.tupleType(), table.keyMapping());
+        this.table = table;
+        this.distributions = distributions;
+        this.indexId = indexId;
+        this.queryString= queryString;
+        this.topN = topN;
+    }
+}

--- a/dingo-exec/src/main/java/io/dingodb/exec/operator/params/TxnPartDocumentParam.java
+++ b/dingo-exec/src/main/java/io/dingodb/exec/operator/params/TxnPartDocumentParam.java
@@ -1,0 +1,177 @@
+/*
+ * Copyright 2021 DataCanvas
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package io.dingodb.exec.operator.params;
+
+import com.fasterxml.jackson.annotation.JsonProperty;
+import com.fasterxml.jackson.annotation.JsonPropertyOrder;
+import com.fasterxml.jackson.annotation.JsonTypeName;
+import io.dingodb.codec.CodecService;
+import io.dingodb.codec.KeyValueCodec;
+import io.dingodb.common.CommonId;
+import io.dingodb.common.CoprocessorV2;
+import io.dingodb.common.partition.RangeDistribution;
+import io.dingodb.common.type.DingoType;
+import io.dingodb.common.type.DingoTypeFactory;
+import io.dingodb.common.type.TupleMapping;
+import io.dingodb.common.util.ByteArrayUtils;
+import io.dingodb.exec.dag.Vertex;
+import io.dingodb.exec.expr.DingoCompileContext;
+import io.dingodb.exec.expr.DingoRelConfig;
+import io.dingodb.exec.expr.SqlExpr;
+import io.dingodb.exec.utils.SchemaWrapperUtils;
+import io.dingodb.expr.coding.CodingFlag;
+import io.dingodb.expr.coding.RelOpCoder;
+import io.dingodb.expr.rel.RelOp;
+import io.dingodb.expr.runtime.type.TupleType;
+import io.dingodb.meta.entity.Column;
+import io.dingodb.meta.entity.IndexTable;
+import io.dingodb.meta.entity.Table;
+import lombok.Getter;
+
+import java.io.ByteArrayOutputStream;
+import java.util.Arrays;
+import java.util.List;
+import java.util.Map;
+import java.util.NavigableMap;
+import java.util.stream.Collectors;
+
+@Getter
+@JsonTypeName("txn_partDocument")
+@JsonPropertyOrder({
+    "tableId", "part", "schema", "keyMapping", "filter", "selection", "indexId", "indexRegionId"
+})
+public class TxnPartDocumentParam extends FilterProjectSourceParam {
+    private KeyValueCodec codec;
+    private final Table table;
+
+    private final NavigableMap<ByteArrayUtils.ComparableByteArray, RangeDistribution> distributions;
+    private final CommonId indexId;
+    private final String queryString;
+    private final int topN;
+    private final IndexTable indexTable;
+
+    private RelOp relOp;
+
+    private final TupleMapping resultSelection;
+
+    @JsonProperty("pushDown")
+    private final boolean pushDown;
+
+    @JsonProperty("scanTs")
+    private long scanTs;
+    @JsonProperty("isolationLevel")
+    private final int isolationLevel;
+    @JsonProperty("timeOut")
+    private final long timeOut;
+
+    private int documentIndex;
+    private CoprocessorV2 coprocessor = null;
+    private final boolean isLookUp;
+    private final DingoType tableDataSchema;
+    private final List<Column> tableDataColList;
+
+    public TxnPartDocumentParam(
+        CommonId partId,
+        SqlExpr filter,
+        TupleMapping selection,
+        DingoType schema,
+        Table table,
+        NavigableMap<ByteArrayUtils.ComparableByteArray, RangeDistribution> distributions,
+        String queryString,
+        int topN,
+        Table indexTable,
+        RelOp relOp,
+        boolean pushDown,
+        boolean isLookUp,
+        long scanTs,
+        int isolationLevel,
+        long timeOut,
+        TupleMapping resultSelection
+    ) {
+        super(table.tableId, partId, schema, table.version, filter, selection, table.keyMapping());
+        this.table = table;
+        this.distributions = distributions;
+        this.indexId = indexTable.tableId;
+        this.queryString = queryString;
+        this.topN = topN;
+        this.indexTable = (IndexTable) indexTable;
+        this.pushDown = pushDown;
+        this.scanTs = scanTs;
+        this.isolationLevel = isolationLevel;
+        this.timeOut = timeOut;
+        this.isLookUp = isLookUp;
+        this.relOp = relOp;
+        this.resultSelection = resultSelection;
+        this.tableDataColList = table.columns.stream().filter(Column::isPrimary).collect(Collectors.toList());
+        tableDataColList.addAll(indexTable.columns.stream()
+            .filter(column -> !column.isPrimary())
+            .collect(Collectors.toList()));
+
+        List<DingoType> priType = tableDataColList.stream().map(Column::getType).collect(Collectors.toList());
+        this.tableDataSchema = DingoTypeFactory.tuple(priType.toArray(new DingoType[]{}));
+    }
+
+    @Override
+    public void init(Vertex vertex) {
+        super.init(vertex);
+        if (pushDown) {
+            CoprocessorV2.CoprocessorV2Builder builder = CoprocessorV2.builder();
+            if (selection != null) {
+                builder.selection(selection.stream().boxed().collect(Collectors.toList()));
+                this.selection = resultSelection;
+            }
+            relOp = relOp.compile(new DingoCompileContext(
+                (TupleType) tableDataSchema.getType(),
+                (TupleType) vertex.getParasType().getType()
+            ), new DingoRelConfig());
+            ByteArrayOutputStream os = new ByteArrayOutputStream();
+            if (RelOpCoder.INSTANCE.visit(relOp, os) == CodingFlag.OK) {
+                builder.relExpr(os.toByteArray());
+                filter = null;
+            }
+            builder.schemaVersion(table.getVersion());
+            builder.originalSchema(
+                SchemaWrapperUtils.buildSchemaWrapper(
+                    tableDataSchema, tableDataKeyMapping(), 0
+                )
+            );
+
+            coprocessor = builder.build();
+        }
+        codec = CodecService.getDefault().createKeyValueCodec(schemaVersion, schema, keyMapping);
+    }
+
+    @Override
+    public void setStartTs(long startTs) {
+        this.scanTs = startTs;
+    }
+
+    public TupleMapping tableDataKeyMapping() {
+        int[] mappings = new int[tableDataSchema.fieldCount()];
+        int keyCount = 0;
+        int colSize = tableDataSchema.fieldCount();
+        for (int i = 0; i < colSize; i++) {
+            int primaryKeyIndex = tableDataColList.get(i).primaryKeyIndex;
+            if (primaryKeyIndex >= 0) {
+                mappings[primaryKeyIndex] = i;
+                keyCount++;
+            }
+        }
+        return TupleMapping.of(Arrays.copyOf(mappings, keyCount));
+    }
+
+}

--- a/dingo-exec/src/main/java/io/dingodb/exec/utils/OperatorCodeUtils.java
+++ b/dingo-exec/src/main/java/io/dingodb/exec/utils/OperatorCodeUtils.java
@@ -34,12 +34,15 @@ public final class OperatorCodeUtils {
     public static final CommonId RECEIVE = new CommonId(CommonId.CommonType.OP, SOURCE, 7);
     public static final CommonId REMOVE_PART = new CommonId(CommonId.CommonType.OP, SOURCE, 8);
     public static final CommonId VALUES = new CommonId(CommonId.CommonType.OP, SOURCE, 9);
+    public static final CommonId PART_DOCUMENT = new CommonId(CommonId.CommonType.OP, SOURCE, 10);
     // txn source
     public static final CommonId TXN_LIKE_SCAN = new CommonId(CommonId.CommonType.OP, SOURCE, 11);
     public static final CommonId SCAN_CACHE = new CommonId(CommonId.CommonType.OP, SOURCE, 12);
     public static final CommonId INFO_SCHEMA_SCAN = new CommonId(CommonId.CommonType.OP, SOURCE, 13);
     public static final CommonId TXN_PART_VECTOR = new CommonId(CommonId.CommonType.OP, SOURCE, 14);
     public static final CommonId CALC_DISTRIBUTION_1 = new CommonId(CommonId.CommonType.OP, SOURCE, 15);
+    public static final CommonId TXN_PART_DOCUMENT = new CommonId(CommonId.CommonType.OP, SOURCE, 16);
+
 
     // op
     public static final CommonId PROJECT = new CommonId(CommonId.CommonType.OP, OP, 20);
@@ -102,6 +105,10 @@ public final class OperatorCodeUtils {
     // sink
     public static final CommonId ROOT = new CommonId(CommonId.CommonType.OP, SINK, 80);
     public static final CommonId SEND = new CommonId(CommonId.CommonType.OP, SINK, 81);
+
+    //document
+    public static final CommonId DOCUMENT_PARTITION = new CommonId(CommonId.CommonType.OP, OP, 90);
+    public static final CommonId DOCUMENT_TOKEN = new CommonId(CommonId.CommonType.OP, OP, 91);
 
     private OperatorCodeUtils() {
     }

--- a/dingo-store-proxy/src/main/java/io/dingodb/store/proxy/service/StoreService.java
+++ b/dingo-store-proxy/src/main/java/io/dingodb/store/proxy/service/StoreService.java
@@ -638,6 +638,9 @@ public final class StoreService implements io.dingodb.store.api.StoreService {
                     .parameter(MAPPER.documentSearchParamTo(documentSearchParameter))
                     .build()
             ).getDocumentWithScores();
+            if (documentWithScores == null || documentWithScores.isEmpty()) {
+                return new ArrayList<io.dingodb.store.api.transaction.data.DocumentWithScore>();
+            }
 
             return documentWithScores.stream().map(MAPPER::documentWithScoreTo).collect(Collectors.toList());
         }


### PR DESCRIPTION
document serarch scenarios:

```
mysql> CREATE TABLE test (        id bigint not null,        feature float array not null,         feature_id bigint not null,        description varchar not null,        category varchar not null,        rating bigint not null,        text_id bigint not null,        INDEX text_index TEXT(text_id, description, category, rating) engine=TXN_BTREE PARTITION BY RANGE values(10) parameters(text_fields='{"description": {"tokenizer": {"type": "stem"}}, "category": {"tokenizer": {"type": "stem"}}, "rating": {"tokenizer": {"type": "i64"}}, "text_id": {"tokenizer": {"type": "i64"}}, "id": {"tokenizer": {"type": "i64"}}}'),       index feature_index vector(feature_id, feature) parameters(type=hnsw, metricType=L2, dimension=8, efConstruction=40, nlinks=32),       primary key(id) ) engine=TXN_LSM;

mysql> insert into test values (1, array[0.19151945412158966, 0.6221087574958801, 0.43772774934768677, 0.7853586077690125, 0.7799758315086365, 0.27259260416030884, 0.2764642536640167, 0.801872193813324], 1, 'Plastic Keyboard', 'Electronics', 4, 1),(2, array[0.959139347076416, 0.8759326338768005, 0.35781726241111755, 0.5009950995445251, 0.683462917804718, 0.7127020359039307, 0.37025076150894165, 0.5611962080001831], 2 , 'Ergonomic metal keyboard', 'Electronics', 4, 2), (3, array[0.5050831437110901, 0.013768449425697327, 0.772826611995697, 0.8826411962509155, 0.36488598585128784, 0.6153962016105652, 0.07538124173879623, 0.3688240051269531], 3, 'Sleek running shoes', 'Footwear', 5, 3), (4, array[0.9361401200294495, 0.6513781547546387, 0.39720258116722107, 0.7887301445007324, 0.3168361186981201, 0.5680986642837524, 0.8691273927688599, 0.4361734092235565], 4, 'Plastic Keyboard', 'Electronics', 4, 4);
Query OK, 4 rows affected (0.24 sec)

mysql> select description, category, rating from text_search(test, test_index, 'DESCRIPTION:keyboard', 5) order by rating;
+--------------------------+-------------+--------+
| description              | category    | rating |
+--------------------------+-------------+--------+
| Plastic Keyboard         | Electronics |      4 |
| Plastic Keyboard         | Electronics |      4 |
| Ergonomic metal keyboard | Electronics |      4 |
+--------------------------+-------------+--------+
3 rows in set (0.03 sec)

```
Note: The column name of search keyword should be uppercase since tantivy is case sensitive, and the column names are coverted to uppercase inside executor.
