### PR TITLE
[feature][dingo-executor] Add the max count limit of mutations in 1pc transaction as 1024.

### DIFF
--- a/dingo-exec/src/main/java/io/dingodb/exec/transaction/base/BaseTransaction.java
+++ b/dingo-exec/src/main/java/io/dingodb/exec/transaction/base/BaseTransaction.java
@@ -95,6 +95,8 @@ public abstract class BaseTransaction implements ITransaction {
     protected CommitProfile commitProfile;
     protected InfoSchema is;
 
+    protected final int maxMutationsForOnePc = 1024;
+
     protected CompletableFuture<Void> finishedFuture = new CompletableFuture<>();
 
     public BaseTransaction(@NonNull CommonId txnId, int isolationLevel) {

--- a/dingo-exec/src/main/java/io/dingodb/exec/transaction/impl/OptimisticTransaction.java
+++ b/dingo-exec/src/main/java/io/dingodb/exec/transaction/impl/OptimisticTransaction.java
@@ -262,6 +262,12 @@ public class OptimisticTransaction extends BaseTransaction {
             }
         }
 
+        if(mutations.size() > maxMutationsForOnePc) {
+            LogUtils.info(log, "{} one pc phase failed, current mutation count:{}, max mutation size:{}",
+                transactionOf(), mutations.size(), maxMutationsForOnePc);
+            throw new OnePcDegenerateTwoPcException("1PC degenerate to 2PC, startTs:" + startTs);
+        }
+
         if(forSamePart) {
             //commit 1pc.
             return txnOnePCCommit(mutations);
@@ -283,7 +289,7 @@ public class OptimisticTransaction extends BaseTransaction {
             .tryOnePc(true)
             .maxCommitTs(0L)
             .lockExtraDatas(TransactionUtil.toLockExtraDataList(cacheToObject.getTableId(), cacheToObject.getPartId(), txnId,
-                TransactionType.OPTIMISTIC.getCode(), 1))
+                TransactionType.OPTIMISTIC.getCode(), mutations.size()))
             .build();
         try {
             StoreInstance store = Services.KV_STORE.getInstance(cacheToObject.getTableId(), cacheToObject.getPartId());

--- a/dingo-exec/src/main/java/io/dingodb/exec/transaction/impl/PessimisticTransaction.java
+++ b/dingo-exec/src/main/java/io/dingodb/exec/transaction/impl/PessimisticTransaction.java
@@ -404,6 +404,12 @@ public class PessimisticTransaction extends BaseTransaction {
             }
         }
 
+        if(mutations.size() > maxMutationsForOnePc) {
+            LogUtils.info(log, "{} one pc phase failed, current mutation count:{}, max mutation size:{}",
+                transactionOf(), mutations.size(), maxMutationsForOnePc);
+            throw new OnePcDegenerateTwoPcException("1PC degenerate to 2PC, startTs:" + startTs);
+        }
+
         if(forSamePart) {
             //commit 1pc.
             return txnOnePCCommit(mutations);


### PR DESCRIPTION
The max count limit of mutations in 1pc transaction is 1024.