### PR TITLE
[feature][dingo-executor]Add the max count limit of mutations in 1pc transaction as 1024.

### DIFF
--- a/dingo-exec/src/main/java/io/dingodb/exec/transaction/impl/PessimisticTransaction.java
+++ b/dingo-exec/src/main/java/io/dingodb/exec/transaction/impl/PessimisticTransaction.java
@@ -404,6 +404,12 @@ public class PessimisticTransaction extends BaseTransaction {
             }
         }
 
+        if(mutations.size() > TransactionUtil.max_pre_write_count) {
+            LogUtils.info(log, "{} one pc phase failed, current mutation count:{}, max mutation size:{}",
+                transactionOf(), mutations.size(), TransactionUtil.max_pre_write_count);
+            throw new OnePcDegenerateTwoPcException("1PC degenerate to 2PC, startTs:" + startTs);
+        }
+
         if(forSamePart) {
             //commit 1pc.
             return txnOnePCCommit(mutations);

--- a/dingo-exec/src/main/java/io/dingodb/exec/transaction/util/TransactionUtil.java
+++ b/dingo-exec/src/main/java/io/dingodb/exec/transaction/util/TransactionUtil.java
@@ -61,6 +61,7 @@ import java.util.stream.IntStream;
 public final class TransactionUtil {
     public static final long lock_ttl = 60000L;
     public static final int max_pre_write_count = 1024;
+    public static final long maxRpcDataSize = 56*1024*1024;
     public static final String snapshotIsolation = "REPEATABLE-READ";
     public static final String readCommitted = "READ-COMMITTED";
 

--- a/dingo-store-proxy/build.gradle
+++ b/dingo-store-proxy/build.gradle
@@ -38,6 +38,7 @@ dependencies {
     implementation project(":dingo-partition-api")
     implementation project(":dingo-tso-api")
     implementation project(":dingo-transaction-api")
+    implementation project(":dingo-exec")
 
     implementation group: 'org.mapstruct', name: 'mapstruct', version: 'mapstruct'.v()
 

--- a/dingo-store-proxy/src/main/java/io/dingodb/store/proxy/service/TransactionStoreInstance.java
+++ b/dingo-store-proxy/src/main/java/io/dingodb/store/proxy/service/TransactionStoreInstance.java
@@ -26,6 +26,7 @@ import io.dingodb.common.mysql.scope.ScopeVariables;
 import io.dingodb.common.profile.OperatorProfile;
 import io.dingodb.common.profile.Profile;
 import io.dingodb.common.type.TupleMapping;
+import io.dingodb.exec.transaction.util.TransactionUtil;
 import io.dingodb.meta.entity.Table;
 import io.dingodb.sdk.common.utils.Optional;
 import io.dingodb.sdk.service.DocumentService;
@@ -102,8 +103,6 @@ public class TransactionStoreInstance {
     private final DocumentService documentService;
 
     private final static int VectorKeyLen = 17;
-    //The max data size for one rpc is 64M, we limit max 1pc data size as 56M now.
-    private final int maxRpcDataSize = 56*1024*1024;
 
     public TransactionStoreInstance(StoreService storeService, IndexService indexService, CommonId partitionId) {
         this(storeService, indexService, null, partitionId);
@@ -163,8 +162,8 @@ public class TransactionStoreInstance {
             TxnPrewriteRequest request = MAPPER.preWriteTo(txnPreWrite);
             TxnPrewriteResponse response;
 
-            if(request.isTryOnePc() && request.sizeOf() > this.maxRpcDataSize) {
-                throw new OnePcMaxSizeExceedException("Data size exceed in 1pc, max:" + this.maxRpcDataSize + " cur:" +request.sizeOf());
+            if(request.isTryOnePc() && request.sizeOf() > TransactionUtil.maxRpcDataSize) {
+                throw new OnePcMaxSizeExceedException("Data size exceed in 1pc, max:" + TransactionUtil.maxRpcDataSize + " cur:" +request.sizeOf());
             }
 
             Mutation mutation = request.getMutations().get(0);


### PR DESCRIPTION
Add the max count limit of mutations in 1pc transaction as 1024.