### PR TITLE
[fix][dingo-executor]Fix trace insert result missing

### DIFF
--- a/dingo-driver/host/src/main/java/io/dingodb/driver/DingoDriverParser.java
+++ b/dingo-driver/host/src/main/java/io/dingodb/driver/DingoDriverParser.java
@@ -521,6 +521,9 @@ public final class DingoDriverParser extends DingoParser {
                     statementType, relNode);
             }
         }
+        if(trace && statementType == Meta.StatementType.IS_DML){
+            statementType = Meta.StatementType.CALL;
+        }
         planProfile.endLock();
         return new DingoSignature(
             enableColumnMetas,


### PR DESCRIPTION
```
mysql> trace insert into t1 values(2000);
+-------------------------+--------------+----------+----------+
| operation               | startTs      | duration | rowcount |
+-------------------------+--------------+----------+----------+
| trace                   | 10:53:42.225 | 3384     |        0 |
|   ©¸©¤compile               | 10:53:42.226 | 3369     |        0 |
|     ©¸©¤parse               | 10:53:42.226 | 7        |        0 |
|     ©¸©¤validate            | 10:53:42.233 | 23       |        0 |
|     ©¸©¤optimize            | 10:53:42.256 | 3278     |        0 |
|   ©¸©¤schedule job          | 10:53:45.596 | 1        |        0 |
|   ©¸©¤runStmt               | 10:53:45.596 | 12       |        1 |
|     ©¸©¤partInsertLocal     | 10:53:45.601 | 7        |        1 |
+-------------------------+--------------+----------+----------+
8 rows in set (3.55 sec)
```
