### PR TITLE
[fix][dingo-executor] Fix topK issue of vector pre filter

### DIFF
--- a/dingo-calcite/src/main/java/io/dingodb/calcite/visitor/function/DingoVectorVisitFun.java
+++ b/dingo-calcite/src/main/java/io/dingodb/calcite/visitor/function/DingoVectorVisitFun.java
@@ -340,6 +340,11 @@ public final class DingoVectorVisitFun {
         return floatArray;
     }
 
+    public static Integer getTopkParam(List<Object> operandsList) {
+        Integer topK = ((Number) Objects.requireNonNull(((SqlNumericLiteral) operandsList.get(3)).getValue())).intValue();
+        return topK;
+    }
+
     private static Map<String, Object> getParameterMap(List<Object> operandsList) {
         Map<String, Object> parameterMap = new HashMap<>();
         if (operandsList.size() >= 5) {

--- a/dingo-driver/host/src/main/java/io/dingodb/driver/DingoDriverParser.java
+++ b/dingo-driver/host/src/main/java/io/dingodb/driver/DingoDriverParser.java
@@ -521,6 +521,9 @@ public final class DingoDriverParser extends DingoParser {
                     statementType, relNode);
             }
         }
+        if(trace && statementType == Meta.StatementType.IS_DML){
+            statementType = Meta.StatementType.CALL;
+        }
         planProfile.endLock();
         return new DingoSignature(
             enableColumnMetas,

--- a/dingo-exec/src/main/java/io/dingodb/exec/operator/params/VectorPointDistanceParam.java
+++ b/dingo-exec/src/main/java/io/dingodb/exec/operator/params/VectorPointDistanceParam.java
@@ -50,6 +50,8 @@ public class VectorPointDistanceParam extends AbstractParams {
 
     private final TupleMapping selection;
 
+    private final Integer topk;
+
     public VectorPointDistanceParam(
         RangeDistribution rangeDistribution,
         Integer vectorIndex,
@@ -58,6 +60,7 @@ public class VectorPointDistanceParam extends AbstractParams {
         Integer dimension,
         String algType,
         String metricType,
+        Integer topk,
         TupleMapping selection
     ) {
         this.rangeDistribution = rangeDistribution;
@@ -69,6 +72,7 @@ public class VectorPointDistanceParam extends AbstractParams {
         this.indexTableId = indexTableId;
         cache = new LinkedList<>();
         this.selection = selection;
+        this.topk = topk;
     }
 
     public void clear() {


### PR DESCRIPTION
```
mysql> select  /*+ vector_pre */ id,feature1_id,feature1_index$distance from
vector(v_index2, feature1, array[10.527543067932129,0.33332860469818115,0.7230303883552551,0.4729453921318054], 5) where feature1_id> -1 order by feature1_id;
+------+-------------+-------------------------+
| id   | feature1_id | feature1_index$distance |
+------+-------------+-------------------------+
|   75 |          76 |               4225.3413 |
|   76 |          77 |               4290.4517 |
|   77 |          78 |                4484.616 |
|   78 |          79 |                4670.204 |
|   79 |          80 |                4696.113 |
|   80 |          81 |               4836.5625 |
|   81 |          82 |                5089.358 |
|   82 |          83 |                5120.474 |
|   83 |          84 |                5302.114 |
|   84 |          85 |               5522.1553 |
|   85 |          86 |               5560.6924 |
|   86 |          87 |               5718.7144 |
|   87 |          88 |                5955.607 |
|   88 |          89 |                6059.314 |
|   89 |          90 |               6234.7583 |
|   90 |          91 |               6353.3774 |
|   91 |          92 |                6579.418 |
|   92 |          93 |                6794.935 |
|   93 |          94 |                6880.161 |
|   94 |          95 |                6986.385 |
|   95 |          96 |               7251.6455 |
|   96 |          97 |                7454.405 |
|   97 |          98 |                7553.535 |
|   98 |          99 |                 7666.82 |
|   99 |         100 |               7872.0425 |
+------+-------------+-------------------------+
25 rows in set (1.19 sec)


```