### PR TITLE
[fix][dingo-executor] Fix nullpointer for ducument search with null field values

### DIFF
--- a/dingo-store-proxy/src/main/java/io/dingodb/store/proxy/mapper/TxnMapper.java
+++ b/dingo-store-proxy/src/main/java/io/dingodb/store/proxy/mapper/TxnMapper.java
@@ -90,10 +90,14 @@ public interface TxnMapper {
     DocumentWithScore documentWithScoreTo(io.dingodb.sdk.service.entity.common.DocumentWithScore documentWithScore);
 
     default DocumentValue documentValueTo(io.dingodb.sdk.service.entity.common.DocumentValue documentValue) {
-        return DocumentValue.builder()
-            .fieldType(scalarFieldTypeTo(documentValue.getFieldType()))
-            .fieldValue(scalarFieldTo(documentValue.getFieldValue()))
-            .build();
+        DocumentValue res = new DocumentValue();
+        if(documentValue.getFieldValue() != null) {
+            return DocumentValue.builder()
+                .fieldType(scalarFieldTypeTo(documentValue.getFieldType()))
+                .fieldValue(scalarFieldTo(documentValue.getFieldValue()))
+                .build();
+        }
+        return  res;
     }
 
     default io.dingodb.sdk.service.entity.common.DocumentValue documentValueTo(DocumentValue documentValue) {


### PR DESCRIPTION
```
mysql> select text_id,description, novel,TEXT_INDEX$RANK_BM25 bm25 from text_search(dis114, text_index, 'novel:hello OR description:test',10);
+---------+-------------+-------+------------+
| text_id | description | novel | bm25       |
+---------+-------------+-------+------------+
|     182 | NULL        | hello | 0.80446345 |
|      13 | Test        | NULL  |  0.6931472 |
|      15 | test        | NULL  |  0.6931472 |
|      14 | Python test | NULL  | 0.49191087 |
|      17 | Test Abc    | NULL  | 0.49191087 |
+---------+-------------+-------+------------+
5 rows in set (4.29 sec)

```