### PR TITLE
[feature][dingo-executor] Support document index datetime and bool type and disk ann index

### DIFF
--- a/dingo-calcite/src/main/codegen/config.fmpp
+++ b/dingo-calcite/src/main/codegen/config.fmpp
@@ -210,6 +210,11 @@ data: {
       "RENAME"
       "TEXT_SEARCH"
       "HYBRID_SEARCH"
+      "DISK_ANN_BUILD"
+      "DISK_ANN_LOAD"
+      "DISK_ANN_STATUS"
+      "DISK_ANN_RESET"
+      "DISK_ANN_COUNT_MEMORY"
     ]
 
     # List of non-reserved keywords to add;

--- a/dingo-calcite/src/main/codegen/includes/parserImpls.ftl
+++ b/dingo-calcite/src/main/codegen/includes/parserImpls.ftl
@@ -1258,5 +1258,85 @@ SqlNode TableFunctionCall() :
         {
             return SqlUserDefinedOperators.HYBRID_SEARCH.createCall(s.end(this), list);
         }
+    |
+        <DISK_ANN_BUILD> { s = span(); } <LPAREN>
+        [
+            AddArg0(list, ExprContext.ACCEPT_CURSOR)
+            (
+                <COMMA> {
+                    // a comma-list can't appear where only a query is expected
+                    checkNonQueryExpression(ExprContext.ACCEPT_CURSOR);
+                }
+                AddArg(list, ExprContext.ACCEPT_CURSOR)
+            )*
+        ]
+        <RPAREN>
+        {
+            return SqlUserDefinedOperators.DISK_ANN_BUILD.createCall(s.end(this), list);
+        }
+    |
+        <DISK_ANN_LOAD> { s = span(); } <LPAREN>
+        [
+            AddArg0(list, ExprContext.ACCEPT_CURSOR)
+            (
+                <COMMA> {
+                    // a comma-list can't appear where only a query is expected
+                    checkNonQueryExpression(ExprContext.ACCEPT_CURSOR);
+                }
+                AddArg(list, ExprContext.ACCEPT_CURSOR)
+            )*
+        ]
+        <RPAREN>
+        {
+            return SqlUserDefinedOperators.DISK_ANN_LOAD.createCall(s.end(this), list);
+        }
+    |
+        <DISK_ANN_STATUS> { s = span(); } <LPAREN>
+        [
+            AddArg0(list, ExprContext.ACCEPT_CURSOR)
+            (
+                <COMMA> {
+                    // a comma-list can't appear where only a query is expected
+                    checkNonQueryExpression(ExprContext.ACCEPT_CURSOR);
+                }
+                AddArg(list, ExprContext.ACCEPT_CURSOR)
+            )*
+        ]
+        <RPAREN>
+        {
+            return SqlUserDefinedOperators.DISK_ANN_STATUS.createCall(s.end(this), list);
+        }
+    |
+        <DISK_ANN_RESET> { s = span(); } <LPAREN>
+        [
+            AddArg0(list, ExprContext.ACCEPT_CURSOR)
+            (
+                <COMMA> {
+                    // a comma-list can't appear where only a query is expected
+                    checkNonQueryExpression(ExprContext.ACCEPT_CURSOR);
+                }
+                AddArg(list, ExprContext.ACCEPT_CURSOR)
+            )*
+        ]
+        <RPAREN>
+        {
+            return SqlUserDefinedOperators.DISK_ANN_RESET.createCall(s.end(this), list);
+        }
+    |
+        <DISK_ANN_COUNT_MEMORY> { s = span(); } <LPAREN>
+        [
+            AddArg0(list, ExprContext.ACCEPT_CURSOR)
+            (
+                <COMMA> {
+                    // a comma-list can't appear where only a query is expected
+                    checkNonQueryExpression(ExprContext.ACCEPT_CURSOR);
+                }
+                AddArg(list, ExprContext.ACCEPT_CURSOR)
+            )*
+        ]
+        <RPAREN>
+        {
+            return SqlUserDefinedOperators.DISK_ANN_COUNT_MEMORY.createCall(s.end(this), list);
+        }
     )
 }

--- a/dingo-calcite/src/main/java/io/dingodb/calcite/DingoDdlExecutor.java
+++ b/dingo-calcite/src/main/java/io/dingodb/calcite/DingoDdlExecutor.java
@@ -1412,7 +1412,9 @@ public class DingoDdlExecutor extends DdlExecutorImpl {
                             && !columnDefinition.getTypeName().equals("DOUBLE")
                             && !columnDefinition.getTypeName().equals("VARCHAR")
                             && !columnDefinition.getTypeName().equals("STRING")
-                            && !columnDefinition.getTypeName().equals("BYTES")) {
+                            && !columnDefinition.getTypeName().equals("BYTES")
+                            && !columnDefinition.getTypeName().equals("TIMESTAMP")
+                            && !columnDefinition.getTypeName().equals("BOOLEAN")) {
                             throw new RuntimeException("Invalid column type: " + columnDefinition.getTypeName());
                         }
                         primary = -1;

--- a/dingo-calcite/src/main/java/io/dingodb/calcite/DingoParserContext.java
+++ b/dingo-calcite/src/main/java/io/dingodb/calcite/DingoParserContext.java
@@ -36,6 +36,7 @@ import org.apache.calcite.rel.type.RelProtoDataType;
 import org.apache.calcite.sql.fun.SqlStdOperatorTable;
 import org.apache.calcite.sql.type.SqlTypeName;
 import org.apache.calcite.sql.util.ReflectiveSqlOperatorTable;
+import org.apache.calcite.sql2rel.SqlDiskAnnOperator;
 import org.apache.calcite.sql2rel.SqlDocumentOperator;
 import org.apache.calcite.sql2rel.SqlFunctionScanOperator;
 import org.apache.calcite.sql2rel.SqlHybridSearchOperator;
@@ -141,11 +142,17 @@ public final class DingoParserContext implements Context {
         tableInstance.register(SqlUserDefinedOperators.SCAN);
         tableInstance.register(SqlUserDefinedOperators.TEXT_SEARCH);
         tableInstance.register(SqlUserDefinedOperators.HYBRID_SEARCH);
+        tableInstance.register(SqlUserDefinedOperators.DISK_ANN_BUILD);
+        tableInstance.register(SqlUserDefinedOperators.DISK_ANN_LOAD);
+        tableInstance.register(SqlUserDefinedOperators.DISK_ANN_STATUS);
+        tableInstance.register(SqlUserDefinedOperators.DISK_ANN_COUNT_MEMORY);
+        tableInstance.register(SqlUserDefinedOperators.DISK_ANN_RESET);
         SqlLikeBinaryOperator.register();
         SqlFunctionScanOperator.register(this);
         SqlVectorOperator.register(this);
         SqlDocumentOperator.register(this);
         SqlHybridSearchOperator.register(this);
+        SqlDiskAnnOperator.register(this);
         // select user from user ; user is default special operator
         eliminateUserOperator(tableInstance);
 

--- a/dingo-calcite/src/main/java/io/dingodb/calcite/DingoSqlValidator.java
+++ b/dingo-calcite/src/main/java/io/dingodb/calcite/DingoSqlValidator.java
@@ -30,8 +30,10 @@ import org.apache.calcite.sql.util.SqlOperatorTables;
 import org.apache.calcite.sql.validate.SqlValidatorImpl;
 import org.apache.calcite.sql.validate.SqlValidatorNamespace;
 import org.apache.calcite.sql.validate.SqlValidatorScope;
+import org.apache.calcite.sql.validate.TableDiskAnnFunctionNamespace;
 import org.apache.calcite.sql.validate.TableFunctionNamespace;
 import org.apache.calcite.sql.validate.TableHybridFunctionNamespace;
+import org.apache.calcite.sql2rel.SqlDiskAnnOperator;
 import org.apache.calcite.sql2rel.SqlDocumentOperator;
 import org.apache.calcite.sql2rel.SqlFunctionScanOperator;
 import org.apache.calcite.sql2rel.SqlHybridSearchOperator;
@@ -101,6 +103,15 @@ public class DingoSqlValidator extends SqlValidatorImpl {
             super.registerNamespace(
                 usingScope, alias,
                 new TableHybridFunctionNamespace(this, (SqlBasicCall) enclosingNode),
+                forceNullable
+            );
+            return;
+        } else if (enclosingNode instanceof SqlBasicCall
+            && (((SqlBasicCall) enclosingNode).getOperator() instanceof SqlDiskAnnOperator)
+        ) {
+            super.registerNamespace(
+                usingScope, alias,
+                new TableDiskAnnFunctionNamespace(this, (SqlBasicCall) enclosingNode),
                 forceNullable
             );
             return;

--- a/dingo-calcite/src/main/java/io/dingodb/calcite/grammar/SqlUserDefinedOperators.java
+++ b/dingo-calcite/src/main/java/io/dingodb/calcite/grammar/SqlUserDefinedOperators.java
@@ -16,11 +16,13 @@
 
 package io.dingodb.calcite.grammar;
 
+import io.dingodb.common.table.DiskAnnTable;
 import io.dingodb.exec.fun.vector.VectorCosineDistanceFun;
 import io.dingodb.exec.fun.vector.VectorIPDistanceFun;
 import io.dingodb.exec.fun.vector.VectorL2DistanceFun;
 import org.apache.calcite.sql.SqlKind;
 import org.apache.calcite.sql2rel.SqlCosineSimilarityOperator;
+import org.apache.calcite.sql2rel.SqlDiskAnnOperator;
 import org.apache.calcite.sql2rel.SqlDocumentOperator;
 import org.apache.calcite.sql2rel.SqlFunctionScanOperator;
 import org.apache.calcite.sql2rel.SqlHybridSearchOperator;
@@ -46,6 +48,16 @@ public class SqlUserDefinedOperators {
     public static SqlDocumentOperator TEXT_SEARCH = new SqlDocumentOperator("TEXT_SEARCH", SqlKind.COLLECTION_TABLE);
 
     public static SqlHybridSearchOperator HYBRID_SEARCH = new SqlHybridSearchOperator("HYBRID_SEARCH", SqlKind.COLLECTION_TABLE);
+
+    public static SqlDiskAnnOperator DISK_ANN_BUILD = new SqlDiskAnnOperator(DiskAnnTable.TABLE_BUILD_NAME, SqlKind.COLLECTION_TABLE);
+
+    public static SqlDiskAnnOperator DISK_ANN_LOAD = new SqlDiskAnnOperator(DiskAnnTable.TABLE_LOAD_NAME, SqlKind.COLLECTION_TABLE);
+
+    public static SqlDiskAnnOperator DISK_ANN_STATUS = new SqlDiskAnnOperator(DiskAnnTable.TABLE_STATUS_NAME, SqlKind.COLLECTION_TABLE);
+
+    public static SqlDiskAnnOperator DISK_ANN_COUNT_MEMORY = new SqlDiskAnnOperator(DiskAnnTable.TABLE_COUNT_MEMORY_NAME, SqlKind.COLLECTION_TABLE);
+
+    public static SqlDiskAnnOperator DISK_ANN_RESET = new SqlDiskAnnOperator(DiskAnnTable.TABLE_RESET_NAME, SqlKind.COLLECTION_TABLE);
 
     public static SqlCosineSimilarityOperator COSINE_SIMILARITY
         = new SqlCosineSimilarityOperator(VectorCosineDistanceFun.NAME, SqlKind.OTHER_FUNCTION);

--- a/dingo-calcite/src/main/java/io/dingodb/calcite/rel/DingoDiskAnnBuild.java
+++ b/dingo-calcite/src/main/java/io/dingodb/calcite/rel/DingoDiskAnnBuild.java
@@ -1,0 +1,94 @@
+/*
+ * Copyright 2021 DataCanvas
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package io.dingodb.calcite.rel;
+
+import io.dingodb.calcite.DingoRelOptTable;
+import io.dingodb.calcite.utils.RelDataTypeUtils;
+import io.dingodb.calcite.visitor.DingoRelVisitor;
+import io.dingodb.common.CommonId;
+import io.dingodb.common.type.TupleMapping;
+import io.dingodb.meta.entity.Table;
+import lombok.Getter;
+import org.apache.calcite.plan.RelOptCluster;
+import org.apache.calcite.plan.RelOptCost;
+import org.apache.calcite.plan.RelOptPlanner;
+import org.apache.calcite.plan.RelTraitSet;
+import org.apache.calcite.rel.RelWriter;
+import org.apache.calcite.rel.hint.RelHint;
+import org.apache.calcite.rel.metadata.RelMetadataQuery;
+import org.apache.calcite.rel.type.RelDataType;
+import org.apache.calcite.rex.RexCall;
+import org.apache.calcite.rex.RexNode;
+import org.checkerframework.checker.nullness.qual.NonNull;
+import org.checkerframework.checker.nullness.qual.Nullable;
+
+import java.util.List;
+
+public class DingoDiskAnnBuild extends LogicalDingoDiskAnnBuild implements DingoRel {
+    @Getter
+    private double rowCount;
+
+    public DingoDiskAnnBuild(
+        RelOptCluster cluster,
+        RelTraitSet traitSet,
+        RexCall call,
+        DingoRelOptTable table,
+        List<Object> operands,
+        @NonNull CommonId indexTableId,
+        @NonNull Table indexTable,
+        TupleMapping selection,
+        RexNode filter,
+        List<RelHint> hints
+    ) {
+        super(cluster, traitSet, call, table, operands, indexTableId, indexTable, selection, filter, hints);
+    }
+
+    @Override
+    public @Nullable RelOptCost computeSelfCost(@NonNull RelOptPlanner planner, @NonNull RelMetadataQuery mq) {
+        return DingoCost.FACTORY.makeCost(Integer.MAX_VALUE, 0, 0);
+    }
+
+    @Override
+    public @NonNull RelWriter explainTerms(@NonNull RelWriter pw) {
+        super.explainTerms(pw);
+        // crucial, this is how Calcite distinguish between different node with different props.
+        return pw;
+    }
+
+    @Override
+    public <T> T accept(@NonNull DingoRelVisitor<T> visitor) {
+        return visitor.visit(this);
+    }
+
+    public RelDataType getNormalRowType() {
+        return getNormalSelectedType();
+    }
+
+    private RelDataType getNormalSelectedType() {
+        return RelDataTypeUtils.mapType(
+            getCluster().getTypeFactory(),
+            getTableType(),
+            selection
+        );
+    }
+
+    @Override
+    public double estimateRowCount(RelMetadataQuery mq) {
+        rowCount = super.estimateRowCount(mq);
+        return rowCount;
+    }
+}

--- a/dingo-calcite/src/main/java/io/dingodb/calcite/rel/DingoDiskAnnCountMemory.java
+++ b/dingo-calcite/src/main/java/io/dingodb/calcite/rel/DingoDiskAnnCountMemory.java
@@ -1,0 +1,94 @@
+/*
+ * Copyright 2021 DataCanvas
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package io.dingodb.calcite.rel;
+
+import io.dingodb.calcite.DingoRelOptTable;
+import io.dingodb.calcite.utils.RelDataTypeUtils;
+import io.dingodb.calcite.visitor.DingoRelVisitor;
+import io.dingodb.common.CommonId;
+import io.dingodb.common.type.TupleMapping;
+import io.dingodb.meta.entity.Table;
+import lombok.Getter;
+import org.apache.calcite.plan.RelOptCluster;
+import org.apache.calcite.plan.RelOptCost;
+import org.apache.calcite.plan.RelOptPlanner;
+import org.apache.calcite.plan.RelTraitSet;
+import org.apache.calcite.rel.RelWriter;
+import org.apache.calcite.rel.hint.RelHint;
+import org.apache.calcite.rel.metadata.RelMetadataQuery;
+import org.apache.calcite.rel.type.RelDataType;
+import org.apache.calcite.rex.RexCall;
+import org.apache.calcite.rex.RexNode;
+import org.checkerframework.checker.nullness.qual.NonNull;
+import org.checkerframework.checker.nullness.qual.Nullable;
+
+import java.util.List;
+
+public class DingoDiskAnnCountMemory extends LogicalDingoDiskAnnCountMemory implements DingoRel {
+    @Getter
+    private double rowCount;
+
+    public DingoDiskAnnCountMemory(
+        RelOptCluster cluster,
+        RelTraitSet traitSet,
+        RexCall call,
+        DingoRelOptTable table,
+        List<Object> operands,
+        @NonNull CommonId indexTableId,
+        @NonNull Table indexTable,
+        TupleMapping selection,
+        RexNode filter,
+        List<RelHint> hints
+    ) {
+        super(cluster, traitSet, call, table, operands, indexTableId, indexTable, selection, filter, hints);
+    }
+
+    @Override
+    public @Nullable RelOptCost computeSelfCost(@NonNull RelOptPlanner planner, @NonNull RelMetadataQuery mq) {
+        return DingoCost.FACTORY.makeCost(Integer.MAX_VALUE, 0, 0);
+    }
+
+    @Override
+    public @NonNull RelWriter explainTerms(@NonNull RelWriter pw) {
+        super.explainTerms(pw);
+        // crucial, this is how Calcite distinguish between different node with different props.
+        return pw;
+    }
+
+    @Override
+    public <T> T accept(@NonNull DingoRelVisitor<T> visitor) {
+        return visitor.visit(this);
+    }
+
+    public RelDataType getNormalRowType() {
+        return getNormalSelectedType();
+    }
+
+    private RelDataType getNormalSelectedType() {
+        return RelDataTypeUtils.mapType(
+            getCluster().getTypeFactory(),
+            getTableType(),
+            selection
+        );
+    }
+
+    @Override
+    public double estimateRowCount(RelMetadataQuery mq) {
+        rowCount = super.estimateRowCount(mq);
+        return rowCount;
+    }
+}

--- a/dingo-calcite/src/main/java/io/dingodb/calcite/rel/DingoDiskAnnLoad.java
+++ b/dingo-calcite/src/main/java/io/dingodb/calcite/rel/DingoDiskAnnLoad.java
@@ -1,0 +1,94 @@
+/*
+ * Copyright 2021 DataCanvas
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package io.dingodb.calcite.rel;
+
+import io.dingodb.calcite.DingoRelOptTable;
+import io.dingodb.calcite.utils.RelDataTypeUtils;
+import io.dingodb.calcite.visitor.DingoRelVisitor;
+import io.dingodb.common.CommonId;
+import io.dingodb.common.type.TupleMapping;
+import io.dingodb.meta.entity.Table;
+import lombok.Getter;
+import org.apache.calcite.plan.RelOptCluster;
+import org.apache.calcite.plan.RelOptCost;
+import org.apache.calcite.plan.RelOptPlanner;
+import org.apache.calcite.plan.RelTraitSet;
+import org.apache.calcite.rel.RelWriter;
+import org.apache.calcite.rel.hint.RelHint;
+import org.apache.calcite.rel.metadata.RelMetadataQuery;
+import org.apache.calcite.rel.type.RelDataType;
+import org.apache.calcite.rex.RexCall;
+import org.apache.calcite.rex.RexNode;
+import org.checkerframework.checker.nullness.qual.NonNull;
+import org.checkerframework.checker.nullness.qual.Nullable;
+
+import java.util.List;
+
+public class DingoDiskAnnLoad extends LogicalDingoDiskAnnBuild implements DingoRel {
+    @Getter
+    private double rowCount;
+
+    public DingoDiskAnnLoad(
+        RelOptCluster cluster,
+        RelTraitSet traitSet,
+        RexCall call,
+        DingoRelOptTable table,
+        List<Object> operands,
+        @NonNull CommonId indexTableId,
+        @NonNull Table indexTable,
+        TupleMapping selection,
+        RexNode filter,
+        List<RelHint> hints
+    ) {
+        super(cluster, traitSet, call, table, operands, indexTableId, indexTable, selection, filter, hints);
+    }
+
+    @Override
+    public @Nullable RelOptCost computeSelfCost(@NonNull RelOptPlanner planner, @NonNull RelMetadataQuery mq) {
+        return DingoCost.FACTORY.makeCost(Integer.MAX_VALUE, 0, 0);
+    }
+
+    @Override
+    public @NonNull RelWriter explainTerms(@NonNull RelWriter pw) {
+        super.explainTerms(pw);
+        // crucial, this is how Calcite distinguish between different node with different props.
+        return pw;
+    }
+
+    @Override
+    public <T> T accept(@NonNull DingoRelVisitor<T> visitor) {
+        return visitor.visit(this);
+    }
+
+    public RelDataType getNormalRowType() {
+        return getNormalSelectedType();
+    }
+
+    private RelDataType getNormalSelectedType() {
+        return RelDataTypeUtils.mapType(
+            getCluster().getTypeFactory(),
+            getTableType(),
+            selection
+        );
+    }
+
+    @Override
+    public double estimateRowCount(RelMetadataQuery mq) {
+        rowCount = super.estimateRowCount(mq);
+        return rowCount;
+    }
+}

--- a/dingo-calcite/src/main/java/io/dingodb/calcite/rel/DingoDiskAnnReset.java
+++ b/dingo-calcite/src/main/java/io/dingodb/calcite/rel/DingoDiskAnnReset.java
@@ -1,0 +1,94 @@
+/*
+ * Copyright 2021 DataCanvas
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package io.dingodb.calcite.rel;
+
+import io.dingodb.calcite.DingoRelOptTable;
+import io.dingodb.calcite.utils.RelDataTypeUtils;
+import io.dingodb.calcite.visitor.DingoRelVisitor;
+import io.dingodb.common.CommonId;
+import io.dingodb.common.type.TupleMapping;
+import io.dingodb.meta.entity.Table;
+import lombok.Getter;
+import org.apache.calcite.plan.RelOptCluster;
+import org.apache.calcite.plan.RelOptCost;
+import org.apache.calcite.plan.RelOptPlanner;
+import org.apache.calcite.plan.RelTraitSet;
+import org.apache.calcite.rel.RelWriter;
+import org.apache.calcite.rel.hint.RelHint;
+import org.apache.calcite.rel.metadata.RelMetadataQuery;
+import org.apache.calcite.rel.type.RelDataType;
+import org.apache.calcite.rex.RexCall;
+import org.apache.calcite.rex.RexNode;
+import org.checkerframework.checker.nullness.qual.NonNull;
+import org.checkerframework.checker.nullness.qual.Nullable;
+
+import java.util.List;
+
+public class DingoDiskAnnReset extends LogicalDingoDiskAnnReset implements DingoRel {
+    @Getter
+    private double rowCount;
+
+    public DingoDiskAnnReset(
+        RelOptCluster cluster,
+        RelTraitSet traitSet,
+        RexCall call,
+        DingoRelOptTable table,
+        List<Object> operands,
+        @NonNull CommonId indexTableId,
+        @NonNull Table indexTable,
+        TupleMapping selection,
+        RexNode filter,
+        List<RelHint> hints
+    ) {
+        super(cluster, traitSet, call, table, operands, indexTableId, indexTable, selection, filter, hints);
+    }
+
+    @Override
+    public @Nullable RelOptCost computeSelfCost(@NonNull RelOptPlanner planner, @NonNull RelMetadataQuery mq) {
+        return DingoCost.FACTORY.makeCost(Integer.MAX_VALUE, 0, 0);
+    }
+
+    @Override
+    public @NonNull RelWriter explainTerms(@NonNull RelWriter pw) {
+        super.explainTerms(pw);
+        // crucial, this is how Calcite distinguish between different node with different props.
+        return pw;
+    }
+
+    @Override
+    public <T> T accept(@NonNull DingoRelVisitor<T> visitor) {
+        return visitor.visit(this);
+    }
+
+    public RelDataType getNormalRowType() {
+        return getNormalSelectedType();
+    }
+
+    private RelDataType getNormalSelectedType() {
+        return RelDataTypeUtils.mapType(
+            getCluster().getTypeFactory(),
+            getTableType(),
+            selection
+        );
+    }
+
+    @Override
+    public double estimateRowCount(RelMetadataQuery mq) {
+        rowCount = super.estimateRowCount(mq);
+        return rowCount;
+    }
+}

--- a/dingo-calcite/src/main/java/io/dingodb/calcite/rel/DingoDiskAnnStatus.java
+++ b/dingo-calcite/src/main/java/io/dingodb/calcite/rel/DingoDiskAnnStatus.java
@@ -1,0 +1,94 @@
+/*
+ * Copyright 2021 DataCanvas
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package io.dingodb.calcite.rel;
+
+import io.dingodb.calcite.DingoRelOptTable;
+import io.dingodb.calcite.utils.RelDataTypeUtils;
+import io.dingodb.calcite.visitor.DingoRelVisitor;
+import io.dingodb.common.CommonId;
+import io.dingodb.common.type.TupleMapping;
+import io.dingodb.meta.entity.Table;
+import lombok.Getter;
+import org.apache.calcite.plan.RelOptCluster;
+import org.apache.calcite.plan.RelOptCost;
+import org.apache.calcite.plan.RelOptPlanner;
+import org.apache.calcite.plan.RelTraitSet;
+import org.apache.calcite.rel.RelWriter;
+import org.apache.calcite.rel.hint.RelHint;
+import org.apache.calcite.rel.metadata.RelMetadataQuery;
+import org.apache.calcite.rel.type.RelDataType;
+import org.apache.calcite.rex.RexCall;
+import org.apache.calcite.rex.RexNode;
+import org.checkerframework.checker.nullness.qual.NonNull;
+import org.checkerframework.checker.nullness.qual.Nullable;
+
+import java.util.List;
+
+public class DingoDiskAnnStatus extends LogicalDingoDiskAnnStatus implements DingoRel {
+    @Getter
+    private double rowCount;
+
+    public DingoDiskAnnStatus(
+        RelOptCluster cluster,
+        RelTraitSet traitSet,
+        RexCall call,
+        DingoRelOptTable table,
+        List<Object> operands,
+        @NonNull CommonId indexTableId,
+        @NonNull Table indexTable,
+        TupleMapping selection,
+        RexNode filter,
+        List<RelHint> hints
+    ) {
+        super(cluster, traitSet, call, table, operands, indexTableId, indexTable, selection, filter, hints);
+    }
+
+    @Override
+    public @Nullable RelOptCost computeSelfCost(@NonNull RelOptPlanner planner, @NonNull RelMetadataQuery mq) {
+        return DingoCost.FACTORY.makeCost(Integer.MAX_VALUE, 0, 0);
+    }
+
+    @Override
+    public @NonNull RelWriter explainTerms(@NonNull RelWriter pw) {
+        super.explainTerms(pw);
+        // crucial, this is how Calcite distinguish between different node with different props.
+        return pw;
+    }
+
+    @Override
+    public <T> T accept(@NonNull DingoRelVisitor<T> visitor) {
+        return visitor.visit(this);
+    }
+
+    public RelDataType getNormalRowType() {
+        return getNormalSelectedType();
+    }
+
+    private RelDataType getNormalSelectedType() {
+        return RelDataTypeUtils.mapType(
+            getCluster().getTypeFactory(),
+            getTableType(),
+            selection
+        );
+    }
+
+    @Override
+    public double estimateRowCount(RelMetadataQuery mq) {
+        rowCount = super.estimateRowCount(mq);
+        return rowCount;
+    }
+}

--- a/dingo-calcite/src/main/java/io/dingodb/calcite/rel/LogicalDingoDiskAnn.java
+++ b/dingo-calcite/src/main/java/io/dingodb/calcite/rel/LogicalDingoDiskAnn.java
@@ -1,0 +1,204 @@
+/*
+ * Copyright 2021 DataCanvas
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package io.dingodb.calcite.rel;
+
+import io.dingodb.calcite.DingoRelOptTable;
+import io.dingodb.calcite.DingoTable;
+import io.dingodb.calcite.utils.RelDataTypeUtils;
+import io.dingodb.common.CommonId;
+import io.dingodb.common.type.DingoType;
+import io.dingodb.common.type.DingoTypeFactory;
+import io.dingodb.common.type.TupleMapping;
+import io.dingodb.common.type.TupleType;
+import io.dingodb.common.type.scalar.FloatType;
+import io.dingodb.meta.entity.Column;
+import io.dingodb.meta.entity.Table;
+import lombok.Getter;
+import lombok.Setter;
+import org.apache.calcite.plan.RelOptCluster;
+import org.apache.calcite.plan.RelTraitSet;
+import org.apache.calcite.rel.RelNode;
+import org.apache.calcite.rel.RelWriter;
+import org.apache.calcite.rel.core.TableFunctionScan;
+import org.apache.calcite.rel.hint.RelHint;
+import org.apache.calcite.rel.metadata.RelColumnMapping;
+import org.apache.calcite.rel.type.RelDataType;
+import org.apache.calcite.rel.type.RelDataTypeFactory;
+import org.apache.calcite.rel.type.RelDataTypeFieldImpl;
+import org.apache.calcite.rex.RexCall;
+import org.apache.calcite.rex.RexNode;
+import org.apache.calcite.sql.type.SqlTypeName;
+import org.checkerframework.checker.nullness.qual.NonNull;
+import org.checkerframework.checker.nullness.qual.Nullable;
+
+import java.lang.reflect.Type;
+import java.util.ArrayList;
+import java.util.Collections;
+import java.util.List;
+import java.util.Set;
+import java.util.stream.Collectors;
+
+public class LogicalDingoDiskAnn extends TableFunctionScan {
+
+    @Getter
+    protected final RexCall call;
+    @Getter
+    protected final DingoRelOptTable table;
+    @Getter
+    protected final List<Object> operands;
+    @Getter
+    protected final CommonId indexTableId;
+    @Getter
+    protected final Table indexTable;
+    @Getter
+    protected final TupleMapping selection;
+    @Getter
+    protected TupleMapping realSelection;
+
+    @Getter
+    protected final RexNode filter;
+
+    @Getter
+    @Setter
+    protected boolean forDml;
+
+    @Getter
+    protected List<RelHint> hints;
+
+    public LogicalDingoDiskAnn(RelOptCluster cluster,
+                               RelTraitSet traitSet,
+                               RexCall call,
+                               DingoRelOptTable table,
+                               List<Object> operands,
+                               @NonNull CommonId indexTableId,
+                               @NonNull Table indexTable,
+                               TupleMapping selection,
+                               RexNode filter,
+                               List<RelHint> hints
+                              ) {
+        super(cluster, traitSet, Collections.emptyList(), call, null, call.type, null);
+        this.call = call;
+        this.table = table;
+        this.operands = operands;
+        this.indexTableId = indexTableId;
+        this.indexTable = indexTable;
+        this.filter = filter;
+        this.rowType = null;
+        this.realSelection = selection;
+        this.hints = hints;
+        DingoTable dingoTable = table.unwrap(DingoTable.class);
+        if (selection != null) {
+            if (forDml) {
+                this.selection = selection;
+            } else {
+                List<Integer> mappingList = new ArrayList<>();
+                for (int index : selection.getMappings()) {
+                    if (index < dingoTable.getTable().getColumns().size()) {
+                        //if (dingoTable.getTable().getColumns().get(index).getState() == 1) {
+                            mappingList.add(index);
+                        //}
+                    } else {
+                        mappingList.add(index);
+                    }
+                }
+                this.selection = TupleMapping.of(mappingList);
+            }
+        } else {
+            assert dingoTable != null;
+            List<Integer> mapping = dingoTable.getTable()
+                .getColumns()
+                .stream()
+                //.filter(col -> col.getState() == 1)
+                .map(col -> dingoTable.getTable().getColumns().indexOf(col))
+                .collect(Collectors.toList());
+            mapping.add(dingoTable.getTable().getColumns().size());
+            this.selection = TupleMapping.of(mapping);
+        }
+    }
+
+    @Override
+    public boolean deepEquals(@Nullable Object obj) {
+        if (obj instanceof LogicalDingoDiskAnn) {
+            LogicalDingoDiskAnn that = (LogicalDingoDiskAnn) obj;
+            boolean result = super.deepEquals(obj);
+            return result && that.filter == filter
+                && that.realSelection == realSelection && that.selection == selection;
+        }
+        return false;
+    }
+
+    @Override
+    public TableFunctionScan copy(RelTraitSet traitSet,
+                                  List<RelNode> inputs,
+                                  RexNode rexCall,
+                                  @Nullable Type elementType,
+                                  RelDataType rowType,
+                                  @Nullable Set<RelColumnMapping> columnMappings) {
+        return new LogicalDingoDiskAnn(
+            getCluster(),
+            traitSet,
+            call, table, operands, indexTableId, indexTable, selection, filter, hints);
+    }
+
+    @Override
+    public @NonNull RelWriter explainTerms(@NonNull RelWriter pw) {
+        super.explainTerms(pw);
+        // crucial, this is how Calcite distinguish between different node with different props.
+        return pw;
+    }
+
+    @Override
+    protected RelDataType deriveRowType() {
+        return getSelectedType();
+    }
+
+    public RelDataType getSelectedType() {
+        return RelDataTypeUtils.mapType(
+            getCluster().getTypeFactory(),
+            getTableType(),
+            realSelection
+        );
+    }
+
+    public RelDataType getTableType() {
+        RelDataType relDataType = table.getRowType();
+        RelDataTypeFactory.Builder builder = getCluster().getTypeFactory().builder();
+        builder.addAll(relDataType.getFieldList());
+        builder.add(new RelDataTypeFieldImpl(
+            indexTable.getName() + "$distance",
+            relDataType.getFieldCount(),
+            getCluster().getTypeFactory().createSqlType(SqlTypeName.get("FLOAT"))));
+        return builder.build();
+    }
+
+    public TupleType tupleType() {
+        DingoTable dingoTable = table.unwrap(DingoTable.class);
+        assert dingoTable != null;
+        ArrayList<Column> cols = new ArrayList<>(dingoTable.getTable().columns.size() + 1);
+        cols.addAll(dingoTable.getTable().columns);
+        cols.add(Column
+            .builder()
+            .name(indexTable.getName().concat("$distance"))
+            .sqlTypeName("FLOAT")
+            .type(new FloatType(false))
+            .precision(-1)
+            .scale(-2147483648)
+            .build());
+        return DingoTypeFactory.tuple(cols.stream().map(Column::getType).toArray(DingoType[]::new));
+    }
+
+}

--- a/dingo-calcite/src/main/java/io/dingodb/calcite/rel/LogicalDingoDiskAnnBuild.java
+++ b/dingo-calcite/src/main/java/io/dingodb/calcite/rel/LogicalDingoDiskAnnBuild.java
@@ -1,0 +1,145 @@
+/*
+ * Copyright 2021 DataCanvas
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package io.dingodb.calcite.rel;
+
+import io.dingodb.calcite.DingoRelOptTable;
+import io.dingodb.calcite.DingoTable;
+import io.dingodb.calcite.utils.RelDataTypeUtils;
+import io.dingodb.common.CommonId;
+import io.dingodb.common.type.DingoType;
+import io.dingodb.common.type.DingoTypeFactory;
+import io.dingodb.common.type.TupleMapping;
+import io.dingodb.common.type.TupleType;
+import io.dingodb.common.type.scalar.LongType;
+import io.dingodb.common.type.scalar.StringType;
+import io.dingodb.meta.entity.Column;
+import io.dingodb.meta.entity.Table;
+import org.apache.calcite.plan.RelOptCluster;
+import org.apache.calcite.plan.RelTraitSet;
+import org.apache.calcite.rel.RelNode;
+import org.apache.calcite.rel.RelWriter;
+import org.apache.calcite.rel.core.TableFunctionScan;
+import org.apache.calcite.rel.hint.RelHint;
+import org.apache.calcite.rel.metadata.RelColumnMapping;
+import org.apache.calcite.rel.type.RelDataType;
+import org.apache.calcite.rel.type.RelDataTypeFactory;
+import org.apache.calcite.rel.type.RelDataTypeFieldImpl;
+import org.apache.calcite.rex.RexCall;
+import org.apache.calcite.rex.RexNode;
+import org.apache.calcite.sql.type.SqlTypeName;
+import org.checkerframework.checker.nullness.qual.NonNull;
+import org.checkerframework.checker.nullness.qual.Nullable;
+
+import java.lang.reflect.Type;
+import java.util.ArrayList;
+import java.util.List;
+import java.util.Set;
+
+public class LogicalDingoDiskAnnBuild extends LogicalDingoDiskAnn {
+
+    public LogicalDingoDiskAnnBuild(RelOptCluster cluster,
+                                    RelTraitSet traitSet,
+                                    RexCall call,
+                                    DingoRelOptTable table,
+                                    List<Object> operands,
+                                    @NonNull CommonId indexTableId,
+                                    @NonNull Table indexTable,
+                                    TupleMapping selection,
+                                    RexNode filter,
+                                    List<RelHint> hints
+                              ) {
+        super(cluster, traitSet, call, table, operands, indexTableId, indexTable, selection, filter, hints);
+    }
+
+    @Override
+    public boolean deepEquals(@Nullable Object obj) {
+        if (obj instanceof LogicalDingoDiskAnnBuild) {
+            LogicalDingoDiskAnnBuild that = (LogicalDingoDiskAnnBuild) obj;
+            boolean result = super.deepEquals(obj);
+            return result && that.filter == filter
+                && that.realSelection == realSelection && that.selection == selection;
+        }
+        return false;
+    }
+
+    @Override
+    public TableFunctionScan copy(RelTraitSet traitSet,
+                                  List<RelNode> inputs,
+                                  RexNode rexCall,
+                                  @Nullable Type elementType,
+                                  RelDataType rowType,
+                                  @Nullable Set<RelColumnMapping> columnMappings) {
+        return new LogicalDingoDiskAnnBuild(
+            getCluster(),
+            traitSet,
+            call, table, operands, indexTableId, indexTable, selection, filter, hints);
+    }
+
+    @Override
+    public @NonNull RelWriter explainTerms(@NonNull RelWriter pw) {
+        super.explainTerms(pw);
+        // crucial, this is how Calcite distinguish between different node with different props.
+        return pw;
+    }
+
+    @Override
+    protected RelDataType deriveRowType() {
+        return getSelectedType();
+    }
+
+    public RelDataType getSelectedType() {
+        return RelDataTypeUtils.mapType(
+            getCluster().getTypeFactory(),
+            getTableType(),
+            realSelection
+        );
+    }
+
+    public RelDataType getTableType() {
+        RelDataType relDataType = table.getRowType();
+        RelDataTypeFactory.Builder builder = getCluster().getTypeFactory().builder();
+        builder.add(new RelDataTypeFieldImpl(
+            indexTable.getName() + "$regionId",
+            relDataType.getFieldCount(),
+            getCluster().getTypeFactory().createSqlType(SqlTypeName.get("BIGINT"))));
+        builder.add(new RelDataTypeFieldImpl(
+            indexTable.getName() + "$status",
+            relDataType.getFieldCount(),
+            getCluster().getTypeFactory().createSqlType(SqlTypeName.get("VARCHAR"))));
+        return builder.build();
+    }
+
+    public TupleType tupleType() {
+        DingoTable dingoTable = table.unwrap(DingoTable.class);
+        assert dingoTable != null;
+        ArrayList<Column> cols = new ArrayList<>();
+        cols.add(Column
+            .builder()
+            .name(indexTable.getName().concat("$regionId"))
+            .sqlTypeName("BIGINT")
+            .type(new LongType(false))
+            .build());
+        cols.add(Column
+            .builder()
+            .name(indexTable.getName().concat("$status"))
+            .sqlTypeName("VARCHAR")
+            .type(new StringType(false))
+            .build());
+        return DingoTypeFactory.tuple(cols.stream().map(Column::getType).toArray(DingoType[]::new));
+    }
+
+}

--- a/dingo-calcite/src/main/java/io/dingodb/calcite/rel/LogicalDingoDiskAnnCountMemory.java
+++ b/dingo-calcite/src/main/java/io/dingodb/calcite/rel/LogicalDingoDiskAnnCountMemory.java
@@ -1,0 +1,145 @@
+/*
+ * Copyright 2021 DataCanvas
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package io.dingodb.calcite.rel;
+
+import io.dingodb.calcite.DingoRelOptTable;
+import io.dingodb.calcite.DingoTable;
+import io.dingodb.calcite.utils.RelDataTypeUtils;
+import io.dingodb.common.CommonId;
+import io.dingodb.common.type.DingoType;
+import io.dingodb.common.type.DingoTypeFactory;
+import io.dingodb.common.type.TupleMapping;
+import io.dingodb.common.type.TupleType;
+import io.dingodb.common.type.scalar.LongType;
+import io.dingodb.common.type.scalar.StringType;
+import io.dingodb.meta.entity.Column;
+import io.dingodb.meta.entity.Table;
+import org.apache.calcite.plan.RelOptCluster;
+import org.apache.calcite.plan.RelTraitSet;
+import org.apache.calcite.rel.RelNode;
+import org.apache.calcite.rel.RelWriter;
+import org.apache.calcite.rel.core.TableFunctionScan;
+import org.apache.calcite.rel.hint.RelHint;
+import org.apache.calcite.rel.metadata.RelColumnMapping;
+import org.apache.calcite.rel.type.RelDataType;
+import org.apache.calcite.rel.type.RelDataTypeFactory;
+import org.apache.calcite.rel.type.RelDataTypeFieldImpl;
+import org.apache.calcite.rex.RexCall;
+import org.apache.calcite.rex.RexNode;
+import org.apache.calcite.sql.type.SqlTypeName;
+import org.checkerframework.checker.nullness.qual.NonNull;
+import org.checkerframework.checker.nullness.qual.Nullable;
+
+import java.lang.reflect.Type;
+import java.util.ArrayList;
+import java.util.List;
+import java.util.Set;
+
+public class LogicalDingoDiskAnnCountMemory extends LogicalDingoDiskAnn {
+
+    public LogicalDingoDiskAnnCountMemory(RelOptCluster cluster,
+                                          RelTraitSet traitSet,
+                                          RexCall call,
+                                          DingoRelOptTable table,
+                                          List<Object> operands,
+                                          @NonNull CommonId indexTableId,
+                                          @NonNull Table indexTable,
+                                          TupleMapping selection,
+                                          RexNode filter,
+                                          List<RelHint> hints
+                              ) {
+        super(cluster, traitSet, call, table, operands, indexTableId, indexTable, selection, filter, hints);
+    }
+
+    @Override
+    public boolean deepEquals(@Nullable Object obj) {
+        if (obj instanceof LogicalDingoDiskAnnCountMemory) {
+            LogicalDingoDiskAnnCountMemory that = (LogicalDingoDiskAnnCountMemory) obj;
+            boolean result = super.deepEquals(obj);
+            return result && that.filter == filter
+                && that.realSelection == realSelection && that.selection == selection;
+        }
+        return false;
+    }
+
+    @Override
+    public TableFunctionScan copy(RelTraitSet traitSet,
+                                  List<RelNode> inputs,
+                                  RexNode rexCall,
+                                  @Nullable Type elementType,
+                                  RelDataType rowType,
+                                  @Nullable Set<RelColumnMapping> columnMappings) {
+        return new LogicalDingoDiskAnnCountMemory(
+            getCluster(),
+            traitSet,
+            call, table, operands, indexTableId, indexTable, selection, filter, hints);
+    }
+
+    @Override
+    public @NonNull RelWriter explainTerms(@NonNull RelWriter pw) {
+        super.explainTerms(pw);
+        // crucial, this is how Calcite distinguish between different node with different props.
+        return pw;
+    }
+
+    @Override
+    protected RelDataType deriveRowType() {
+        return getSelectedType();
+    }
+
+    public RelDataType getSelectedType() {
+        return RelDataTypeUtils.mapType(
+            getCluster().getTypeFactory(),
+            getTableType(),
+            realSelection
+        );
+    }
+
+    public RelDataType getTableType() {
+        RelDataType relDataType = table.getRowType();
+        RelDataTypeFactory.Builder builder = getCluster().getTypeFactory().builder();
+        builder.add(new RelDataTypeFieldImpl(
+            indexTable.getName() + "$regionId",
+            relDataType.getFieldCount(),
+            getCluster().getTypeFactory().createSqlType(SqlTypeName.get("BIGINT"))));
+        builder.add(new RelDataTypeFieldImpl(
+            indexTable.getName() + "$count",
+            relDataType.getFieldCount(),
+            getCluster().getTypeFactory().createSqlType(SqlTypeName.get("BIGINT"))));
+        return builder.build();
+    }
+
+    public TupleType tupleType() {
+        DingoTable dingoTable = table.unwrap(DingoTable.class);
+        assert dingoTable != null;
+        ArrayList<Column> cols = new ArrayList<>();
+        cols.add(Column
+            .builder()
+            .name(indexTable.getName().concat("$regionId"))
+            .sqlTypeName("BIGINT")
+            .type(new LongType(false))
+            .build());
+        cols.add(Column
+            .builder()
+            .name(indexTable.getName().concat("$count"))
+            .sqlTypeName("BIGINT")
+            .type(new LongType(false))
+            .build());
+        return DingoTypeFactory.tuple(cols.stream().map(Column::getType).toArray(DingoType[]::new));
+    }
+
+}

--- a/dingo-calcite/src/main/java/io/dingodb/calcite/rel/LogicalDingoDiskAnnLoad.java
+++ b/dingo-calcite/src/main/java/io/dingodb/calcite/rel/LogicalDingoDiskAnnLoad.java
@@ -1,0 +1,145 @@
+/*
+ * Copyright 2021 DataCanvas
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package io.dingodb.calcite.rel;
+
+import io.dingodb.calcite.DingoRelOptTable;
+import io.dingodb.calcite.DingoTable;
+import io.dingodb.calcite.utils.RelDataTypeUtils;
+import io.dingodb.common.CommonId;
+import io.dingodb.common.type.DingoType;
+import io.dingodb.common.type.DingoTypeFactory;
+import io.dingodb.common.type.TupleMapping;
+import io.dingodb.common.type.TupleType;
+import io.dingodb.common.type.scalar.LongType;
+import io.dingodb.common.type.scalar.StringType;
+import io.dingodb.meta.entity.Column;
+import io.dingodb.meta.entity.Table;
+import org.apache.calcite.plan.RelOptCluster;
+import org.apache.calcite.plan.RelTraitSet;
+import org.apache.calcite.rel.RelNode;
+import org.apache.calcite.rel.RelWriter;
+import org.apache.calcite.rel.core.TableFunctionScan;
+import org.apache.calcite.rel.hint.RelHint;
+import org.apache.calcite.rel.metadata.RelColumnMapping;
+import org.apache.calcite.rel.type.RelDataType;
+import org.apache.calcite.rel.type.RelDataTypeFactory;
+import org.apache.calcite.rel.type.RelDataTypeFieldImpl;
+import org.apache.calcite.rex.RexCall;
+import org.apache.calcite.rex.RexNode;
+import org.apache.calcite.sql.type.SqlTypeName;
+import org.checkerframework.checker.nullness.qual.NonNull;
+import org.checkerframework.checker.nullness.qual.Nullable;
+
+import java.lang.reflect.Type;
+import java.util.ArrayList;
+import java.util.List;
+import java.util.Set;
+
+public class LogicalDingoDiskAnnLoad extends LogicalDingoDiskAnn {
+
+    public LogicalDingoDiskAnnLoad(RelOptCluster cluster,
+                                   RelTraitSet traitSet,
+                                   RexCall call,
+                                   DingoRelOptTable table,
+                                   List<Object> operands,
+                                   @NonNull CommonId indexTableId,
+                                   @NonNull Table indexTable,
+                                   TupleMapping selection,
+                                   RexNode filter,
+                                   List<RelHint> hints
+                              ) {
+        super(cluster, traitSet, call, table, operands, indexTableId, indexTable, selection, filter, hints);
+    }
+
+    @Override
+    public boolean deepEquals(@Nullable Object obj) {
+        if (obj instanceof LogicalDingoDiskAnnLoad) {
+            LogicalDingoDiskAnnLoad that = (LogicalDingoDiskAnnLoad) obj;
+            boolean result = super.deepEquals(obj);
+            return result && that.filter == filter
+                && that.realSelection == realSelection && that.selection == selection;
+        }
+        return false;
+    }
+
+    @Override
+    public TableFunctionScan copy(RelTraitSet traitSet,
+                                  List<RelNode> inputs,
+                                  RexNode rexCall,
+                                  @Nullable Type elementType,
+                                  RelDataType rowType,
+                                  @Nullable Set<RelColumnMapping> columnMappings) {
+        return new LogicalDingoDiskAnnLoad(
+            getCluster(),
+            traitSet,
+            call, table, operands, indexTableId, indexTable, selection, filter, hints);
+    }
+
+    @Override
+    public @NonNull RelWriter explainTerms(@NonNull RelWriter pw) {
+        super.explainTerms(pw);
+        // crucial, this is how Calcite distinguish between different node with different props.
+        return pw;
+    }
+
+    @Override
+    protected RelDataType deriveRowType() {
+        return getSelectedType();
+    }
+
+    public RelDataType getSelectedType() {
+        return RelDataTypeUtils.mapType(
+            getCluster().getTypeFactory(),
+            getTableType(),
+            realSelection
+        );
+    }
+
+    public RelDataType getTableType() {
+        RelDataType relDataType = table.getRowType();
+        RelDataTypeFactory.Builder builder = getCluster().getTypeFactory().builder();
+        builder.add(new RelDataTypeFieldImpl(
+            indexTable.getName() + "$regionId",
+            relDataType.getFieldCount(),
+            getCluster().getTypeFactory().createSqlType(SqlTypeName.get("BIGINT"))));
+        builder.add(new RelDataTypeFieldImpl(
+            indexTable.getName() + "$status",
+            relDataType.getFieldCount(),
+            getCluster().getTypeFactory().createSqlType(SqlTypeName.get("VARCHAR"))));
+        return builder.build();
+    }
+
+    public TupleType tupleType() {
+        DingoTable dingoTable = table.unwrap(DingoTable.class);
+        assert dingoTable != null;
+        ArrayList<Column> cols = new ArrayList<>();
+        cols.add(Column
+            .builder()
+            .name(indexTable.getName().concat("$regionId"))
+            .sqlTypeName("BIGINT")
+            .type(new LongType(false))
+            .build());
+        cols.add(Column
+            .builder()
+            .name(indexTable.getName().concat("$status"))
+            .sqlTypeName("VARCHAR")
+            .type(new StringType(false))
+            .build());
+        return DingoTypeFactory.tuple(cols.stream().map(Column::getType).toArray(DingoType[]::new));
+    }
+
+}

--- a/dingo-calcite/src/main/java/io/dingodb/calcite/rel/LogicalDingoDiskAnnReset.java
+++ b/dingo-calcite/src/main/java/io/dingodb/calcite/rel/LogicalDingoDiskAnnReset.java
@@ -1,0 +1,145 @@
+/*
+ * Copyright 2021 DataCanvas
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package io.dingodb.calcite.rel;
+
+import io.dingodb.calcite.DingoRelOptTable;
+import io.dingodb.calcite.DingoTable;
+import io.dingodb.calcite.utils.RelDataTypeUtils;
+import io.dingodb.common.CommonId;
+import io.dingodb.common.type.DingoType;
+import io.dingodb.common.type.DingoTypeFactory;
+import io.dingodb.common.type.TupleMapping;
+import io.dingodb.common.type.TupleType;
+import io.dingodb.common.type.scalar.LongType;
+import io.dingodb.common.type.scalar.StringType;
+import io.dingodb.meta.entity.Column;
+import io.dingodb.meta.entity.Table;
+import org.apache.calcite.plan.RelOptCluster;
+import org.apache.calcite.plan.RelTraitSet;
+import org.apache.calcite.rel.RelNode;
+import org.apache.calcite.rel.RelWriter;
+import org.apache.calcite.rel.core.TableFunctionScan;
+import org.apache.calcite.rel.hint.RelHint;
+import org.apache.calcite.rel.metadata.RelColumnMapping;
+import org.apache.calcite.rel.type.RelDataType;
+import org.apache.calcite.rel.type.RelDataTypeFactory;
+import org.apache.calcite.rel.type.RelDataTypeFieldImpl;
+import org.apache.calcite.rex.RexCall;
+import org.apache.calcite.rex.RexNode;
+import org.apache.calcite.sql.type.SqlTypeName;
+import org.checkerframework.checker.nullness.qual.NonNull;
+import org.checkerframework.checker.nullness.qual.Nullable;
+
+import java.lang.reflect.Type;
+import java.util.ArrayList;
+import java.util.List;
+import java.util.Set;
+
+public class LogicalDingoDiskAnnReset extends LogicalDingoDiskAnn {
+
+    public LogicalDingoDiskAnnReset(RelOptCluster cluster,
+                                    RelTraitSet traitSet,
+                                    RexCall call,
+                                    DingoRelOptTable table,
+                                    List<Object> operands,
+                                    @NonNull CommonId indexTableId,
+                                    @NonNull Table indexTable,
+                                    TupleMapping selection,
+                                    RexNode filter,
+                                    List<RelHint> hints
+                              ) {
+        super(cluster, traitSet, call, table, operands, indexTableId, indexTable, selection, filter, hints);
+    }
+
+    @Override
+    public boolean deepEquals(@Nullable Object obj) {
+        if (obj instanceof LogicalDingoDiskAnnReset) {
+            LogicalDingoDiskAnnReset that = (LogicalDingoDiskAnnReset) obj;
+            boolean result = super.deepEquals(obj);
+            return result && that.filter == filter
+                && that.realSelection == realSelection && that.selection == selection;
+        }
+        return false;
+    }
+
+    @Override
+    public TableFunctionScan copy(RelTraitSet traitSet,
+                                  List<RelNode> inputs,
+                                  RexNode rexCall,
+                                  @Nullable Type elementType,
+                                  RelDataType rowType,
+                                  @Nullable Set<RelColumnMapping> columnMappings) {
+        return new LogicalDingoDiskAnnReset(
+            getCluster(),
+            traitSet,
+            call, table, operands, indexTableId, indexTable, selection, filter, hints);
+    }
+
+    @Override
+    public @NonNull RelWriter explainTerms(@NonNull RelWriter pw) {
+        super.explainTerms(pw);
+        // crucial, this is how Calcite distinguish between different node with different props.
+        return pw;
+    }
+
+    @Override
+    protected RelDataType deriveRowType() {
+        return getSelectedType();
+    }
+
+    public RelDataType getSelectedType() {
+        return RelDataTypeUtils.mapType(
+            getCluster().getTypeFactory(),
+            getTableType(),
+            realSelection
+        );
+    }
+
+    public RelDataType getTableType() {
+        RelDataType relDataType = table.getRowType();
+        RelDataTypeFactory.Builder builder = getCluster().getTypeFactory().builder();
+        builder.add(new RelDataTypeFieldImpl(
+            indexTable.getName() + "$regionId",
+            relDataType.getFieldCount(),
+            getCluster().getTypeFactory().createSqlType(SqlTypeName.get("BIGINT"))));
+        builder.add(new RelDataTypeFieldImpl(
+            indexTable.getName() + "$status",
+            relDataType.getFieldCount(),
+            getCluster().getTypeFactory().createSqlType(SqlTypeName.get("VARCHAR"))));
+        return builder.build();
+    }
+
+    public TupleType tupleType() {
+        DingoTable dingoTable = table.unwrap(DingoTable.class);
+        assert dingoTable != null;
+        ArrayList<Column> cols = new ArrayList<>();
+        cols.add(Column
+            .builder()
+            .name(indexTable.getName().concat("$regionId"))
+            .sqlTypeName("BIGINT")
+            .type(new LongType(false))
+            .build());
+        cols.add(Column
+            .builder()
+            .name(indexTable.getName().concat("$status"))
+            .sqlTypeName("VARCHAR")
+            .type(new StringType(false))
+            .build());
+        return DingoTypeFactory.tuple(cols.stream().map(Column::getType).toArray(DingoType[]::new));
+    }
+
+}

--- a/dingo-calcite/src/main/java/io/dingodb/calcite/rel/LogicalDingoDiskAnnStatus.java
+++ b/dingo-calcite/src/main/java/io/dingodb/calcite/rel/LogicalDingoDiskAnnStatus.java
@@ -1,0 +1,150 @@
+/*
+ * Copyright 2021 DataCanvas
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package io.dingodb.calcite.rel;
+
+import io.dingodb.calcite.DingoRelOptTable;
+import io.dingodb.calcite.DingoTable;
+import io.dingodb.calcite.utils.RelDataTypeUtils;
+import io.dingodb.common.CommonId;
+import io.dingodb.common.type.DingoType;
+import io.dingodb.common.type.DingoTypeFactory;
+import io.dingodb.common.type.TupleMapping;
+import io.dingodb.common.type.TupleType;
+import io.dingodb.common.type.scalar.FloatType;
+import io.dingodb.common.type.scalar.LongType;
+import io.dingodb.common.type.scalar.StringType;
+import io.dingodb.meta.entity.Column;
+import io.dingodb.meta.entity.Table;
+import lombok.Getter;
+import lombok.Setter;
+import org.apache.calcite.plan.RelOptCluster;
+import org.apache.calcite.plan.RelTraitSet;
+import org.apache.calcite.rel.RelNode;
+import org.apache.calcite.rel.RelWriter;
+import org.apache.calcite.rel.core.TableFunctionScan;
+import org.apache.calcite.rel.hint.RelHint;
+import org.apache.calcite.rel.metadata.RelColumnMapping;
+import org.apache.calcite.rel.type.RelDataType;
+import org.apache.calcite.rel.type.RelDataTypeFactory;
+import org.apache.calcite.rel.type.RelDataTypeFieldImpl;
+import org.apache.calcite.rex.RexCall;
+import org.apache.calcite.rex.RexNode;
+import org.apache.calcite.sql.type.SqlTypeName;
+import org.checkerframework.checker.nullness.qual.NonNull;
+import org.checkerframework.checker.nullness.qual.Nullable;
+
+import java.lang.reflect.Type;
+import java.util.ArrayList;
+import java.util.Collections;
+import java.util.List;
+import java.util.Set;
+import java.util.stream.Collectors;
+
+public class LogicalDingoDiskAnnStatus extends LogicalDingoDiskAnn {
+
+    public LogicalDingoDiskAnnStatus(RelOptCluster cluster,
+                                     RelTraitSet traitSet,
+                                     RexCall call,
+                                     DingoRelOptTable table,
+                                     List<Object> operands,
+                                     @NonNull CommonId indexTableId,
+                                     @NonNull Table indexTable,
+                                     TupleMapping selection,
+                                     RexNode filter,
+                                     List<RelHint> hints
+                              ) {
+        super(cluster, traitSet, call, table, operands, indexTableId, indexTable, selection, filter, hints);
+    }
+
+    @Override
+    public boolean deepEquals(@Nullable Object obj) {
+        if (obj instanceof LogicalDingoDiskAnnStatus) {
+            LogicalDingoDiskAnnStatus that = (LogicalDingoDiskAnnStatus) obj;
+            boolean result = super.deepEquals(obj);
+            return result && that.filter == filter
+                && that.realSelection == realSelection && that.selection == selection;
+        }
+        return false;
+    }
+
+    @Override
+    public TableFunctionScan copy(RelTraitSet traitSet,
+                                  List<RelNode> inputs,
+                                  RexNode rexCall,
+                                  @Nullable Type elementType,
+                                  RelDataType rowType,
+                                  @Nullable Set<RelColumnMapping> columnMappings) {
+        return new LogicalDingoDiskAnnStatus(
+            getCluster(),
+            traitSet,
+            call, table, operands, indexTableId, indexTable, selection, filter, hints);
+    }
+
+    @Override
+    public @NonNull RelWriter explainTerms(@NonNull RelWriter pw) {
+        super.explainTerms(pw);
+        // crucial, this is how Calcite distinguish between different node with different props.
+        return pw;
+    }
+
+    @Override
+    protected RelDataType deriveRowType() {
+        return getSelectedType();
+    }
+
+    public RelDataType getSelectedType() {
+        return RelDataTypeUtils.mapType(
+            getCluster().getTypeFactory(),
+            getTableType(),
+            realSelection
+        );
+    }
+
+    public RelDataType getTableType() {
+        RelDataType relDataType = table.getRowType();
+        RelDataTypeFactory.Builder builder = getCluster().getTypeFactory().builder();
+        builder.add(new RelDataTypeFieldImpl(
+            indexTable.getName() + "$regionId",
+            relDataType.getFieldCount(),
+            getCluster().getTypeFactory().createSqlType(SqlTypeName.get("BIGINT"))));
+        builder.add(new RelDataTypeFieldImpl(
+            indexTable.getName() + "$status",
+            relDataType.getFieldCount(),
+            getCluster().getTypeFactory().createSqlType(SqlTypeName.get("VARCHAR"))));
+        return builder.build();
+    }
+
+    public TupleType tupleType() {
+        DingoTable dingoTable = table.unwrap(DingoTable.class);
+        assert dingoTable != null;
+        ArrayList<Column> cols = new ArrayList<>();
+        cols.add(Column
+            .builder()
+            .name(indexTable.getName().concat("$regionId"))
+            .sqlTypeName("BIGINT")
+            .type(new LongType(false))
+            .build());
+        cols.add(Column
+            .builder()
+            .name(indexTable.getName().concat("$status"))
+            .sqlTypeName("VARCHAR")
+            .type(new StringType(false))
+            .build());
+        return DingoTypeFactory.tuple(cols.stream().map(Column::getType).toArray(DingoType[]::new));
+    }
+
+}

--- a/dingo-calcite/src/main/java/io/dingodb/calcite/rule/DingoFunctionScanRule.java
+++ b/dingo-calcite/src/main/java/io/dingodb/calcite/rule/DingoFunctionScanRule.java
@@ -16,10 +16,20 @@
 
 package io.dingodb.calcite.rule;
 
+import io.dingodb.calcite.rel.DingoDiskAnnBuild;
+import io.dingodb.calcite.rel.DingoDiskAnnCountMemory;
+import io.dingodb.calcite.rel.DingoDiskAnnLoad;
+import io.dingodb.calcite.rel.DingoDiskAnnReset;
+import io.dingodb.calcite.rel.DingoDiskAnnStatus;
 import io.dingodb.calcite.rel.DingoDocument;
 import io.dingodb.calcite.rel.DingoFunctionScan;
 import io.dingodb.calcite.rel.DingoHybridSearch;
 import io.dingodb.calcite.rel.DingoVector;
+import io.dingodb.calcite.rel.LogicalDingoDiskAnnBuild;
+import io.dingodb.calcite.rel.LogicalDingoDiskAnnCountMemory;
+import io.dingodb.calcite.rel.LogicalDingoDiskAnnLoad;
+import io.dingodb.calcite.rel.LogicalDingoDiskAnnReset;
+import io.dingodb.calcite.rel.LogicalDingoDiskAnnStatus;
 import io.dingodb.calcite.rel.LogicalDingoDocument;
 import io.dingodb.calcite.rel.LogicalDingoHybridSearch;
 import io.dingodb.calcite.rel.LogicalDingoVector;
@@ -99,6 +109,76 @@ public class DingoFunctionScanRule extends ConverterRule {
                 hybridSearch.getSelection(),
                 hybridSearch.getFilter(),
                 hybridSearch.hints
+            );
+        } else if (rel instanceof LogicalDingoDiskAnnBuild && !(rel instanceof DingoDiskAnnBuild)) {
+            LogicalDingoDiskAnnBuild vector = (LogicalDingoDiskAnnBuild) rel;
+            return new DingoDiskAnnBuild(
+                vector.getCluster(),
+                traits,
+                vector.getCall(),
+                vector.getTable(),
+                vector.getOperands(),
+                vector.getIndexTableId(),
+                vector.getIndexTable(),
+                vector.getSelection(),
+                vector.getFilter(),
+                vector.getHints()
+            );
+        } else if (rel instanceof LogicalDingoDiskAnnLoad && !(rel instanceof DingoDiskAnnLoad)) {
+            LogicalDingoDiskAnnLoad vector = (LogicalDingoDiskAnnLoad) rel;
+            return new DingoDiskAnnLoad(
+                vector.getCluster(),
+                traits,
+                vector.getCall(),
+                vector.getTable(),
+                vector.getOperands(),
+                vector.getIndexTableId(),
+                vector.getIndexTable(),
+                vector.getSelection(),
+                vector.getFilter(),
+                vector.getHints()
+            );
+        } else if (rel instanceof LogicalDingoDiskAnnStatus && !(rel instanceof DingoDiskAnnStatus)) {
+            LogicalDingoDiskAnnStatus vector = (LogicalDingoDiskAnnStatus) rel;
+            return new DingoDiskAnnStatus(
+                vector.getCluster(),
+                traits,
+                vector.getCall(),
+                vector.getTable(),
+                vector.getOperands(),
+                vector.getIndexTableId(),
+                vector.getIndexTable(),
+                vector.getSelection(),
+                vector.getFilter(),
+                vector.getHints()
+            );
+        } else if (rel instanceof LogicalDingoDiskAnnCountMemory && !(rel instanceof DingoDiskAnnCountMemory)) {
+            LogicalDingoDiskAnnCountMemory vector = (LogicalDingoDiskAnnCountMemory) rel;
+            return new DingoDiskAnnCountMemory(
+                vector.getCluster(),
+                traits,
+                vector.getCall(),
+                vector.getTable(),
+                vector.getOperands(),
+                vector.getIndexTableId(),
+                vector.getIndexTable(),
+                vector.getSelection(),
+                vector.getFilter(),
+                vector.getHints()
+            );
+        } else if (rel instanceof LogicalDingoDiskAnnReset && !(rel instanceof DingoDiskAnnReset)) {
+            LogicalDingoDiskAnnReset vector = (LogicalDingoDiskAnnReset) rel;
+            return new DingoDiskAnnReset(
+                vector.getCluster(),
+                traits,
+                vector.getCall(),
+                vector.getTable(),
+                vector.getOperands(),
+                vector.getIndexTableId(),
+                vector.getIndexTable(),
+                vector.getSelection(),
+                vector.getFilter(),
+                vector.getHints()
             );
         } else if (rel instanceof DingoFunctionScan) {
             DingoFunctionScan scan = (DingoFunctionScan) rel;

--- a/dingo-calcite/src/main/java/io/dingodb/calcite/visitor/DingoExplainVisitor.java
+++ b/dingo-calcite/src/main/java/io/dingodb/calcite/visitor/DingoExplainVisitor.java
@@ -18,6 +18,11 @@ package io.dingodb.calcite.visitor;
 
 import io.dingodb.calcite.DingoTable;
 import io.dingodb.calcite.rel.DingoAggregate;
+import io.dingodb.calcite.rel.DingoDiskAnnBuild;
+import io.dingodb.calcite.rel.DingoDiskAnnCountMemory;
+import io.dingodb.calcite.rel.DingoDiskAnnLoad;
+import io.dingodb.calcite.rel.DingoDiskAnnReset;
+import io.dingodb.calcite.rel.DingoDiskAnnStatus;
 import io.dingodb.calcite.rel.DingoDocument;
 import io.dingodb.calcite.rel.DingoExportData;
 import io.dingodb.calcite.rel.DingoFilter;
@@ -519,4 +524,83 @@ public class DingoExplainVisitor implements DingoRelVisitor<Explain> {
         return explain1;
     }
 
+    @Override
+    public Explain visit(@NonNull DingoDiskAnnStatus dingoDiskAnnStatus) {
+        String filter = "";
+        if (dingoDiskAnnStatus.getFilter() != null) {
+            filter = dingoDiskAnnStatus.getFilter().toString();
+        }
+        String tableNames = "";
+        if (dingoDiskAnnStatus.getIndexTable() != null) {
+            tableNames = dingoDiskAnnStatus.getIndexTable().getName();
+        }
+        return new Explain(
+            "dingoDiskAnnStatus", dingoDiskAnnStatus.getRowCount(), "root",
+            tableNames, filter
+        );
+    }
+
+    @Override
+    public Explain visit(@NonNull DingoDiskAnnCountMemory dingoDiskAnnCountMemory) {
+        String filter = "";
+        if (dingoDiskAnnCountMemory.getFilter() != null) {
+            filter = dingoDiskAnnCountMemory.getFilter().toString();
+        }
+        String tableNames = "";
+        if (dingoDiskAnnCountMemory.getIndexTable() != null) {
+            tableNames = dingoDiskAnnCountMemory.getIndexTable().getName();
+        }
+        return new Explain(
+            "dingoDiskAnnCountMemory", dingoDiskAnnCountMemory.getRowCount(), "root",
+            tableNames, filter
+        );
+    }
+
+    @Override
+    public Explain visit(@NonNull DingoDiskAnnReset dingoDiskAnnReset) {
+        String filter = "";
+        if (dingoDiskAnnReset.getFilter() != null) {
+            filter = dingoDiskAnnReset.getFilter().toString();
+        }
+        String tableNames = "";
+        if (dingoDiskAnnReset.getIndexTable() != null) {
+            tableNames = dingoDiskAnnReset.getIndexTable().getName();
+        }
+        return new Explain(
+            "dingoDiskAnnReset", dingoDiskAnnReset.getRowCount(), "root",
+            tableNames, filter
+        );
+    }
+
+    @Override
+    public Explain visit(@NonNull DingoDiskAnnBuild dingoDiskAnnBuild) {
+        String filter = "";
+        if (dingoDiskAnnBuild.getFilter() != null) {
+            filter = dingoDiskAnnBuild.getFilter().toString();
+        }
+        String tableNames = "";
+        if (dingoDiskAnnBuild.getIndexTable() != null) {
+            tableNames = dingoDiskAnnBuild.getIndexTable().getName();
+        }
+        return new Explain(
+            "dingoDiskAnnBuild", dingoDiskAnnBuild.getRowCount(), "root",
+            tableNames, filter
+        );
+    }
+
+    @Override
+    public Explain visit(@NonNull DingoDiskAnnLoad dingoDiskAnnLoad) {
+        String filter = "";
+        if (dingoDiskAnnLoad.getFilter() != null) {
+            filter = dingoDiskAnnLoad.getFilter().toString();
+        }
+        String tableNames = "";
+        if (dingoDiskAnnLoad.getIndexTable() != null) {
+            tableNames = dingoDiskAnnLoad.getIndexTable().getName();
+        }
+        return new Explain(
+            "dingoDiskAnnLoad", dingoDiskAnnLoad.getRowCount(), "root",
+            tableNames, filter
+        );
+    }
 }

--- a/dingo-calcite/src/main/java/io/dingodb/calcite/visitor/DingoJobVisitor.java
+++ b/dingo-calcite/src/main/java/io/dingodb/calcite/visitor/DingoJobVisitor.java
@@ -17,6 +17,11 @@
 package io.dingodb.calcite.visitor;
 
 import io.dingodb.calcite.rel.DingoAggregate;
+import io.dingodb.calcite.rel.DingoDiskAnnBuild;
+import io.dingodb.calcite.rel.DingoDiskAnnCountMemory;
+import io.dingodb.calcite.rel.DingoDiskAnnLoad;
+import io.dingodb.calcite.rel.DingoDiskAnnReset;
+import io.dingodb.calcite.rel.DingoDiskAnnStatus;
 import io.dingodb.calcite.rel.DingoDocument;
 import io.dingodb.calcite.rel.DingoExportData;
 import io.dingodb.calcite.rel.DingoFilter;
@@ -52,6 +57,11 @@ import io.dingodb.calcite.rel.dingo.IndexFullScan;
 import io.dingodb.calcite.rel.dingo.IndexRangeScan;
 import io.dingodb.calcite.visitor.function.DingoAggregateVisitFun;
 import io.dingodb.calcite.visitor.function.DingoCountDeleteVisitFun;
+import io.dingodb.calcite.visitor.function.DingoDiskAnnBuildVisitFun;
+import io.dingodb.calcite.visitor.function.DingoDiskAnnCountMemoryVisitFun;
+import io.dingodb.calcite.visitor.function.DingoDiskAnnLoadVisitFun;
+import io.dingodb.calcite.visitor.function.DingoDiskAnnResetVisitFun;
+import io.dingodb.calcite.visitor.function.DingoDiskAnnStatusVisitFun;
 import io.dingodb.calcite.visitor.function.DingoDocumentStreamingVisitFun;
 import io.dingodb.calcite.visitor.function.DingoDocumentVisitFun;
 import io.dingodb.calcite.visitor.function.DingoExportDataVisitFun;
@@ -328,4 +338,28 @@ public class DingoJobVisitor implements DingoRelVisitor<Collection<Vertex>> {
         return DingoIndexScanWithRelOpVisitFun.visit(job, idGenerator, currentLocation, transaction, this, rel);
     }
 
+    @Override
+    public Collection<Vertex> visit(@NonNull DingoDiskAnnStatus dingoDiskAnnStatus) {
+        return DingoDiskAnnStatusVisitFun.visit(job, idGenerator, currentLocation, transaction, this, dingoDiskAnnStatus);
+    }
+
+    @Override
+    public Collection<Vertex> visit(@NonNull DingoDiskAnnCountMemory dingoDiskAnnCountMemory) {
+        return DingoDiskAnnCountMemoryVisitFun.visit(job, idGenerator, currentLocation, transaction, this, dingoDiskAnnCountMemory);
+    }
+
+    @Override
+    public Collection<Vertex> visit(@NonNull DingoDiskAnnReset dingoDiskAnnReset) {
+        return DingoDiskAnnResetVisitFun.visit(job, idGenerator, currentLocation, transaction, this, dingoDiskAnnReset);
+    }
+
+    @Override
+    public Collection<Vertex> visit(@NonNull DingoDiskAnnBuild dingoDiskAnnBuild) {
+        return DingoDiskAnnBuildVisitFun.visit(job, idGenerator, currentLocation, transaction, this, dingoDiskAnnBuild);
+    }
+
+    @Override
+    public Collection<Vertex> visit(@NonNull DingoDiskAnnLoad dingoDiskAnnLoad) {
+        return DingoDiskAnnLoadVisitFun.visit(job, idGenerator, currentLocation, transaction, this, dingoDiskAnnLoad);
+    }
 }

--- a/dingo-calcite/src/main/java/io/dingodb/calcite/visitor/DingoRelVisitor.java
+++ b/dingo-calcite/src/main/java/io/dingodb/calcite/visitor/DingoRelVisitor.java
@@ -17,6 +17,11 @@
 package io.dingodb.calcite.visitor;
 
 import io.dingodb.calcite.rel.DingoAggregate;
+import io.dingodb.calcite.rel.DingoDiskAnnBuild;
+import io.dingodb.calcite.rel.DingoDiskAnnCountMemory;
+import io.dingodb.calcite.rel.DingoDiskAnnLoad;
+import io.dingodb.calcite.rel.DingoDiskAnnReset;
+import io.dingodb.calcite.rel.DingoDiskAnnStatus;
 import io.dingodb.calcite.rel.DingoDocument;
 import io.dingodb.calcite.rel.DingoExportData;
 import io.dingodb.calcite.rel.DingoFilter;
@@ -120,4 +125,14 @@ public interface DingoRelVisitor<T> {
     T visitDingoAggregateReduce(@NonNull DingoReduceAggregate rel);
 
     T visitDingoIndexScanWithRelOp(@NonNull DingoIndexScanWithRelOp rel);
+
+    T visit(@NonNull DingoDiskAnnStatus dingoDiskAnnStatus);
+
+    T visit(@NonNull DingoDiskAnnCountMemory dingoDiskAnnCountMemory);
+
+    T visit(@NonNull DingoDiskAnnReset dingoDiskAnnReset);
+
+    T visit(@NonNull DingoDiskAnnBuild dingoDiskAnnBuild);
+
+    T visit(@NonNull DingoDiskAnnLoad dingoDiskAnnLoad);
 }

--- a/dingo-calcite/src/main/java/io/dingodb/calcite/visitor/function/DingoDiskAnnBuildVisitFun.java
+++ b/dingo-calcite/src/main/java/io/dingodb/calcite/visitor/function/DingoDiskAnnBuildVisitFun.java
@@ -1,0 +1,139 @@
+/*
+ * Copyright 2021 DataCanvas
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package io.dingodb.calcite.visitor.function;
+
+import io.dingodb.calcite.DingoRelOptTable;
+import io.dingodb.calcite.DingoTable;
+import io.dingodb.calcite.rel.DingoDiskAnnBuild;
+import io.dingodb.calcite.utils.SqlExprUtils;
+import io.dingodb.calcite.utils.VisitUtils;
+import io.dingodb.calcite.visitor.DingoJobVisitor;
+import io.dingodb.common.CommonId;
+import io.dingodb.common.Location;
+import io.dingodb.common.partition.RangeDistribution;
+import io.dingodb.common.type.TupleMapping;
+import io.dingodb.common.util.ByteArrayUtils.ComparableByteArray;
+import io.dingodb.common.util.Optional;
+import io.dingodb.exec.base.IdGenerator;
+import io.dingodb.exec.base.Job;
+import io.dingodb.exec.base.OutputHint;
+import io.dingodb.exec.base.Task;
+import io.dingodb.exec.dag.Vertex;
+import io.dingodb.exec.expr.SqlExpr;
+import io.dingodb.exec.operator.params.TxnDiskAnnBuildParam;
+import io.dingodb.exec.transaction.base.ITransaction;
+import io.dingodb.meta.MetaService;
+import io.dingodb.meta.entity.IndexTable;
+import io.dingodb.meta.entity.Table;
+import lombok.extern.slf4j.Slf4j;
+import org.apache.calcite.rex.RexNode;
+import org.apache.calcite.sql.SqlIdentifier;
+import org.apache.calcite.sql.SqlNumericLiteral;
+
+import java.util.ArrayList;
+import java.util.Collection;
+import java.util.List;
+import java.util.NavigableMap;
+import java.util.Objects;
+
+import static io.dingodb.exec.utils.OperatorCodeUtils.TXN_DISK_ANN_BUILD;
+
+@Slf4j
+public final class DingoDiskAnnBuildVisitFun {
+
+
+    private DingoDiskAnnBuildVisitFun() {
+
+    }
+
+    public static Collection<Vertex> visit(
+        Job job, IdGenerator idGenerator, Location currentLocation,
+        ITransaction transaction, DingoJobVisitor visitor, DingoDiskAnnBuild rel
+    ) {
+        if (transaction == null) {
+            throw new RuntimeException("not support Non-transaction");
+        }
+        DingoRelOptTable relTable = rel.getTable();
+        DingoTable dingoTable = relTable.unwrap(DingoTable.class);
+
+        MetaService metaService = MetaService.root();
+        assert dingoTable != null;
+        CommonId tableId = dingoTable.getTableId();
+        Table td = dingoTable.getTable();
+
+        NavigableMap<ComparableByteArray, RangeDistribution> ranges = metaService.getRangeDistribution(tableId);
+        List<Object> operandsList = rel.getOperands();
+        String indexName = Objects.requireNonNull((SqlIdentifier) operandsList.get(1)).toString();
+        String indexTableName = rel.getIndexTable().getName();
+        if(!indexTableName.equalsIgnoreCase(indexName)){
+            throw new IllegalArgumentException("Can not find the text index with name: " + indexName);
+        }
+        long ts = 0L;
+        long reginId = 0L;
+        if (operandsList.size() == 3) {
+            ts = ((Number) Objects.requireNonNull(((SqlNumericLiteral) operandsList.get(2)).getValue())).longValue();
+        }
+        if (operandsList.size() == 4) {
+            ts = ((Number) Objects.requireNonNull(((SqlNumericLiteral) operandsList.get(2)).getValue())).longValue();
+            reginId = ((Number) Objects.requireNonNull(((SqlNumericLiteral) operandsList.get(3)).getValue())).longValue();
+        }
+        List<Vertex> outputs = new ArrayList<>();
+        IndexTable indexTable = (IndexTable) rel.getIndexTable();
+        RexNode rexFilter = rel.getFilter();
+        TupleMapping resultSelection = rel.getSelection();
+        long scanTs = VisitUtils.getScanTs(transaction, visitor.getKind());
+
+        SqlExpr filter = null;
+        if (rexFilter != null) {
+            filter = SqlExprUtils.toSqlExpr(rexFilter);
+        }
+        // Get all index table distributions
+        NavigableMap<ComparableByteArray, RangeDistribution> indexRanges =
+            metaService.getRangeDistribution(rel.getIndexTableId());
+
+        // Create tasks based on partitions
+        for (RangeDistribution rangeDistribution : indexRanges.values()) {
+            if (reginId != 0 && rangeDistribution.id().seq != reginId) {
+                continue;
+            }
+            TxnDiskAnnBuildParam param = new TxnDiskAnnBuildParam(
+                rangeDistribution.id(),
+                Optional.mapOrNull(filter, SqlExpr::copy),
+                resultSelection,
+                rel.tupleType(),
+                td,
+                ranges,
+                indexTable,
+                scanTs,
+                transaction.getIsolationLevel(),
+                transaction.getLockTimeOut(),
+                ts
+                );
+            Vertex vertex = new Vertex(TXN_DISK_ANN_BUILD, param);
+            Task task = job.getOrCreate(currentLocation, idGenerator);
+            OutputHint hint = new OutputHint();
+            hint.setPartId(rangeDistribution.id());
+            vertex.setHint(hint);
+            vertex.setId(idGenerator.getOperatorId(task.getId()));
+            task.putVertex(vertex);
+            outputs.add(vertex);
+        }
+        visitor.setScan(true);
+        return outputs;
+    }
+
+}

--- a/dingo-calcite/src/main/java/io/dingodb/calcite/visitor/function/DingoDiskAnnCountMemoryVisitFun.java
+++ b/dingo-calcite/src/main/java/io/dingodb/calcite/visitor/function/DingoDiskAnnCountMemoryVisitFun.java
@@ -1,0 +1,126 @@
+/*
+ * Copyright 2021 DataCanvas
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package io.dingodb.calcite.visitor.function;
+
+import io.dingodb.calcite.DingoRelOptTable;
+import io.dingodb.calcite.DingoTable;
+import io.dingodb.calcite.rel.DingoDiskAnnCountMemory;
+import io.dingodb.calcite.utils.SqlExprUtils;
+import io.dingodb.calcite.utils.VisitUtils;
+import io.dingodb.calcite.visitor.DingoJobVisitor;
+import io.dingodb.common.CommonId;
+import io.dingodb.common.Location;
+import io.dingodb.common.partition.RangeDistribution;
+import io.dingodb.common.type.TupleMapping;
+import io.dingodb.common.util.ByteArrayUtils.ComparableByteArray;
+import io.dingodb.common.util.Optional;
+import io.dingodb.exec.base.IdGenerator;
+import io.dingodb.exec.base.Job;
+import io.dingodb.exec.base.OutputHint;
+import io.dingodb.exec.base.Task;
+import io.dingodb.exec.dag.Vertex;
+import io.dingodb.exec.expr.SqlExpr;
+import io.dingodb.exec.operator.params.TxnDiskAnnCountMemoryParam;
+import io.dingodb.exec.transaction.base.ITransaction;
+import io.dingodb.meta.MetaService;
+import io.dingodb.meta.entity.IndexTable;
+import io.dingodb.meta.entity.Table;
+import lombok.extern.slf4j.Slf4j;
+import org.apache.calcite.rex.RexNode;
+import org.apache.calcite.sql.SqlIdentifier;
+
+import java.util.ArrayList;
+import java.util.Collection;
+import java.util.List;
+import java.util.NavigableMap;
+import java.util.Objects;
+
+import static io.dingodb.exec.utils.OperatorCodeUtils.TXN_DISK_ANN_COUNT_MEMORY;
+
+@Slf4j
+public final class DingoDiskAnnCountMemoryVisitFun {
+
+
+    private DingoDiskAnnCountMemoryVisitFun() {
+
+    }
+
+    public static Collection<Vertex> visit(
+        Job job, IdGenerator idGenerator, Location currentLocation,
+        ITransaction transaction, DingoJobVisitor visitor, DingoDiskAnnCountMemory rel
+    ) {
+        if (transaction == null) {
+            throw new RuntimeException("not support Non-transaction");
+        }
+        DingoRelOptTable relTable = rel.getTable();
+        DingoTable dingoTable = relTable.unwrap(DingoTable.class);
+
+        MetaService metaService = MetaService.root();
+        assert dingoTable != null;
+        CommonId tableId = dingoTable.getTableId();
+        Table td = dingoTable.getTable();
+
+        NavigableMap<ComparableByteArray, RangeDistribution> ranges = metaService.getRangeDistribution(tableId);
+        List<Object> operandsList = rel.getOperands();
+        String indexName = Objects.requireNonNull((SqlIdentifier) operandsList.get(1)).toString();
+        String indexTableName = rel.getIndexTable().getName();
+        if(!indexTableName.equalsIgnoreCase(indexName)){
+            throw new IllegalArgumentException("Can not find the text index with name: " + indexName);
+        }
+
+        List<Vertex> outputs = new ArrayList<>();
+        IndexTable indexTable = (IndexTable) rel.getIndexTable();
+        RexNode rexFilter = rel.getFilter();
+        TupleMapping resultSelection = rel.getSelection();
+        long scanTs = VisitUtils.getScanTs(transaction, visitor.getKind());
+
+        SqlExpr filter = null;
+        if (rexFilter != null) {
+            filter = SqlExprUtils.toSqlExpr(rexFilter);
+        }
+        // Get all index table distributions
+        NavigableMap<ComparableByteArray, RangeDistribution> indexRanges =
+            metaService.getRangeDistribution(rel.getIndexTableId());
+
+        // Create tasks based on partitions
+        for (RangeDistribution rangeDistribution : indexRanges.values()) {
+            TxnDiskAnnCountMemoryParam param = new TxnDiskAnnCountMemoryParam(
+                rangeDistribution.id(),
+                Optional.mapOrNull(filter, SqlExpr::copy),
+                resultSelection,
+                rel.tupleType(),
+                td,
+                ranges,
+                indexTable,
+                scanTs,
+                transaction.getIsolationLevel(),
+                transaction.getLockTimeOut()
+                );
+            Vertex vertex = new Vertex(TXN_DISK_ANN_COUNT_MEMORY, param);
+            Task task = job.getOrCreate(currentLocation, idGenerator);
+            OutputHint hint = new OutputHint();
+            hint.setPartId(rangeDistribution.id());
+            vertex.setHint(hint);
+            vertex.setId(idGenerator.getOperatorId(task.getId()));
+            task.putVertex(vertex);
+            outputs.add(vertex);
+        }
+        visitor.setScan(true);
+        return outputs;
+    }
+
+}

--- a/dingo-calcite/src/main/java/io/dingodb/calcite/visitor/function/DingoDiskAnnLoadVisitFun.java
+++ b/dingo-calcite/src/main/java/io/dingodb/calcite/visitor/function/DingoDiskAnnLoadVisitFun.java
@@ -1,0 +1,147 @@
+/*
+ * Copyright 2021 DataCanvas
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package io.dingodb.calcite.visitor.function;
+
+import io.dingodb.calcite.DingoRelOptTable;
+import io.dingodb.calcite.DingoTable;
+import io.dingodb.calcite.rel.DingoDiskAnnLoad;
+import io.dingodb.calcite.utils.SqlExprUtils;
+import io.dingodb.calcite.utils.VisitUtils;
+import io.dingodb.calcite.visitor.DingoJobVisitor;
+import io.dingodb.common.CommonId;
+import io.dingodb.common.Location;
+import io.dingodb.common.partition.RangeDistribution;
+import io.dingodb.common.type.TupleMapping;
+import io.dingodb.common.util.ByteArrayUtils.ComparableByteArray;
+import io.dingodb.common.util.Optional;
+import io.dingodb.exec.base.IdGenerator;
+import io.dingodb.exec.base.Job;
+import io.dingodb.exec.base.OutputHint;
+import io.dingodb.exec.base.Task;
+import io.dingodb.exec.dag.Vertex;
+import io.dingodb.exec.expr.SqlExpr;
+import io.dingodb.exec.operator.params.TxnDiskAnnLoadParam;
+import io.dingodb.exec.transaction.base.ITransaction;
+import io.dingodb.meta.MetaService;
+import io.dingodb.meta.entity.IndexTable;
+import io.dingodb.meta.entity.Table;
+import lombok.extern.slf4j.Slf4j;
+import org.apache.calcite.rex.RexNode;
+import org.apache.calcite.sql.SqlIdentifier;
+import org.apache.calcite.sql.SqlLiteral;
+import org.apache.calcite.sql.SqlNumericLiteral;
+
+import java.util.ArrayList;
+import java.util.Collection;
+import java.util.List;
+import java.util.NavigableMap;
+import java.util.Objects;
+
+import static io.dingodb.exec.utils.OperatorCodeUtils.TXN_DISK_ANN_LOAD;
+
+@Slf4j
+public final class DingoDiskAnnLoadVisitFun {
+
+
+    private DingoDiskAnnLoadVisitFun() {
+
+    }
+
+    public static Collection<Vertex> visit(
+        Job job, IdGenerator idGenerator, Location currentLocation,
+        ITransaction transaction, DingoJobVisitor visitor, DingoDiskAnnLoad rel
+    ) {
+        if (transaction == null) {
+            throw new RuntimeException("not support Non-transaction");
+        }
+        DingoRelOptTable relTable = rel.getTable();
+        DingoTable dingoTable = relTable.unwrap(DingoTable.class);
+
+        MetaService metaService = MetaService.root();
+        assert dingoTable != null;
+        CommonId tableId = dingoTable.getTableId();
+        Table td = dingoTable.getTable();
+
+        NavigableMap<ComparableByteArray, RangeDistribution> ranges = metaService.getRangeDistribution(tableId);
+        List<Object> operandsList = rel.getOperands();
+        String indexName = Objects.requireNonNull((SqlIdentifier) operandsList.get(1)).toString();
+        String indexTableName = rel.getIndexTable().getName();
+        if(!indexTableName.equalsIgnoreCase(indexName)){
+            throw new IllegalArgumentException("Can not find the text index with name: " + indexName);
+        }
+        int nodesCacheNum = 0;
+        boolean warmup = true;
+        long regionId = 0L;
+        if (operandsList.size() == 3) {
+            nodesCacheNum = ((Number) Objects.requireNonNull(((SqlNumericLiteral) operandsList.get(2)).getValue())).intValue();
+        }
+        if (operandsList.size() == 4) {
+            nodesCacheNum = ((Number) Objects.requireNonNull(((SqlNumericLiteral) operandsList.get(2)).getValue())).intValue();
+            warmup = ((Boolean) Objects.requireNonNull(((SqlLiteral) operandsList.get(3)).getValue()));
+        }
+        if (operandsList.size() == 5) {
+            nodesCacheNum = ((Number) Objects.requireNonNull(((SqlNumericLiteral) operandsList.get(2)).getValue())).intValue();
+            warmup = ((Boolean) Objects.requireNonNull(((SqlLiteral) operandsList.get(3)).getValue()));
+            regionId = ((Number) Objects.requireNonNull(((SqlNumericLiteral) operandsList.get(4)).getValue())).longValue();
+        }
+        List<Vertex> outputs = new ArrayList<>();
+        IndexTable indexTable = (IndexTable) rel.getIndexTable();
+        RexNode rexFilter = rel.getFilter();
+        TupleMapping resultSelection = rel.getSelection();
+        long scanTs = VisitUtils.getScanTs(transaction, visitor.getKind());
+
+        SqlExpr filter = null;
+        if (rexFilter != null) {
+            filter = SqlExprUtils.toSqlExpr(rexFilter);
+        }
+        // Get all index table distributions
+        NavigableMap<ComparableByteArray, RangeDistribution> indexRanges =
+            metaService.getRangeDistribution(rel.getIndexTableId());
+
+        // Create tasks based on partitions
+        for (RangeDistribution rangeDistribution : indexRanges.values()) {
+            if (regionId != 0 && rangeDistribution.id().seq != regionId) {
+                continue;
+            }
+            TxnDiskAnnLoadParam param = new TxnDiskAnnLoadParam(
+                rangeDistribution.id(),
+                Optional.mapOrNull(filter, SqlExpr::copy),
+                resultSelection,
+                rel.tupleType(),
+                td,
+                ranges,
+                indexTable,
+                scanTs,
+                transaction.getIsolationLevel(),
+                transaction.getLockTimeOut(),
+                nodesCacheNum,
+                warmup
+                );
+            Vertex vertex = new Vertex(TXN_DISK_ANN_LOAD, param);
+            Task task = job.getOrCreate(currentLocation, idGenerator);
+            OutputHint hint = new OutputHint();
+            hint.setPartId(rangeDistribution.id());
+            vertex.setHint(hint);
+            vertex.setId(idGenerator.getOperatorId(task.getId()));
+            task.putVertex(vertex);
+            outputs.add(vertex);
+        }
+        visitor.setScan(true);
+        return outputs;
+    }
+
+}

--- a/dingo-calcite/src/main/java/io/dingodb/calcite/visitor/function/DingoDiskAnnResetVisitFun.java
+++ b/dingo-calcite/src/main/java/io/dingodb/calcite/visitor/function/DingoDiskAnnResetVisitFun.java
@@ -1,0 +1,134 @@
+/*
+ * Copyright 2021 DataCanvas
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package io.dingodb.calcite.visitor.function;
+
+import io.dingodb.calcite.DingoRelOptTable;
+import io.dingodb.calcite.DingoTable;
+import io.dingodb.calcite.rel.DingoDiskAnnReset;
+import io.dingodb.calcite.utils.SqlExprUtils;
+import io.dingodb.calcite.utils.VisitUtils;
+import io.dingodb.calcite.visitor.DingoJobVisitor;
+import io.dingodb.common.CommonId;
+import io.dingodb.common.Location;
+import io.dingodb.common.partition.RangeDistribution;
+import io.dingodb.common.type.TupleMapping;
+import io.dingodb.common.util.ByteArrayUtils.ComparableByteArray;
+import io.dingodb.common.util.Optional;
+import io.dingodb.exec.base.IdGenerator;
+import io.dingodb.exec.base.Job;
+import io.dingodb.exec.base.OutputHint;
+import io.dingodb.exec.base.Task;
+import io.dingodb.exec.dag.Vertex;
+import io.dingodb.exec.expr.SqlExpr;
+import io.dingodb.exec.operator.params.TxnDiskAnnResetParam;
+import io.dingodb.exec.transaction.base.ITransaction;
+import io.dingodb.meta.MetaService;
+import io.dingodb.meta.entity.IndexTable;
+import io.dingodb.meta.entity.Table;
+import lombok.extern.slf4j.Slf4j;
+import org.apache.calcite.rex.RexNode;
+import org.apache.calcite.sql.SqlIdentifier;
+import org.apache.calcite.sql.SqlNumericLiteral;
+
+import java.util.ArrayList;
+import java.util.Collection;
+import java.util.List;
+import java.util.NavigableMap;
+import java.util.Objects;
+
+import static io.dingodb.exec.utils.OperatorCodeUtils.TXN_DISK_ANN_RESET;
+
+@Slf4j
+public final class DingoDiskAnnResetVisitFun {
+
+
+    private DingoDiskAnnResetVisitFun() {
+
+    }
+
+    public static Collection<Vertex> visit(
+        Job job, IdGenerator idGenerator, Location currentLocation,
+        ITransaction transaction, DingoJobVisitor visitor, DingoDiskAnnReset rel
+    ) {
+        if (transaction == null) {
+            throw new RuntimeException("not support Non-transaction");
+        }
+        DingoRelOptTable relTable = rel.getTable();
+        DingoTable dingoTable = relTable.unwrap(DingoTable.class);
+
+        MetaService metaService = MetaService.root();
+        assert dingoTable != null;
+        CommonId tableId = dingoTable.getTableId();
+        Table td = dingoTable.getTable();
+
+        NavigableMap<ComparableByteArray, RangeDistribution> ranges = metaService.getRangeDistribution(tableId);
+        List<Object> operandsList = rel.getOperands();
+        String indexName = Objects.requireNonNull((SqlIdentifier) operandsList.get(1)).toString();
+        String indexTableName = rel.getIndexTable().getName();
+        if(!indexTableName.equalsIgnoreCase(indexName)){
+            throw new IllegalArgumentException("Can not find the text index with name: " + indexName);
+        }
+        long reginId = 0L;
+        if (operandsList.size() == 3) {
+            reginId = ((Number) Objects.requireNonNull(((SqlNumericLiteral) operandsList.get(2)).getValue())).longValue();
+        }
+
+        List<Vertex> outputs = new ArrayList<>();
+        IndexTable indexTable = (IndexTable) rel.getIndexTable();
+        RexNode rexFilter = rel.getFilter();
+        TupleMapping resultSelection = rel.getSelection();
+        long scanTs = VisitUtils.getScanTs(transaction, visitor.getKind());
+
+        SqlExpr filter = null;
+        if (rexFilter != null) {
+            filter = SqlExprUtils.toSqlExpr(rexFilter);
+        }
+        // Get all index table distributions
+        NavigableMap<ComparableByteArray, RangeDistribution> indexRanges =
+            metaService.getRangeDistribution(rel.getIndexTableId());
+
+        // Create tasks based on partitions
+        for (RangeDistribution rangeDistribution : indexRanges.values()) {
+            if (reginId != 0 && rangeDistribution.id().seq != reginId) {
+                continue;
+            }
+            TxnDiskAnnResetParam param = new TxnDiskAnnResetParam(
+                rangeDistribution.id(),
+                Optional.mapOrNull(filter, SqlExpr::copy),
+                resultSelection,
+                rel.tupleType(),
+                td,
+                ranges,
+                indexTable,
+                scanTs,
+                transaction.getIsolationLevel(),
+                transaction.getLockTimeOut()
+                );
+            Vertex vertex = new Vertex(TXN_DISK_ANN_RESET, param);
+            Task task = job.getOrCreate(currentLocation, idGenerator);
+            OutputHint hint = new OutputHint();
+            hint.setPartId(rangeDistribution.id());
+            vertex.setHint(hint);
+            vertex.setId(idGenerator.getOperatorId(task.getId()));
+            task.putVertex(vertex);
+            outputs.add(vertex);
+        }
+        visitor.setScan(true);
+        return outputs;
+    }
+
+}

--- a/dingo-calcite/src/main/java/io/dingodb/calcite/visitor/function/DingoDiskAnnStatusVisitFun.java
+++ b/dingo-calcite/src/main/java/io/dingodb/calcite/visitor/function/DingoDiskAnnStatusVisitFun.java
@@ -1,0 +1,126 @@
+/*
+ * Copyright 2021 DataCanvas
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package io.dingodb.calcite.visitor.function;
+
+import io.dingodb.calcite.DingoRelOptTable;
+import io.dingodb.calcite.DingoTable;
+import io.dingodb.calcite.rel.DingoDiskAnnStatus;
+import io.dingodb.calcite.utils.SqlExprUtils;
+import io.dingodb.calcite.utils.VisitUtils;
+import io.dingodb.calcite.visitor.DingoJobVisitor;
+import io.dingodb.common.CommonId;
+import io.dingodb.common.Location;
+import io.dingodb.common.partition.RangeDistribution;
+import io.dingodb.common.type.TupleMapping;
+import io.dingodb.common.util.ByteArrayUtils.ComparableByteArray;
+import io.dingodb.common.util.Optional;
+import io.dingodb.exec.base.IdGenerator;
+import io.dingodb.exec.base.Job;
+import io.dingodb.exec.base.OutputHint;
+import io.dingodb.exec.base.Task;
+import io.dingodb.exec.dag.Vertex;
+import io.dingodb.exec.expr.SqlExpr;
+import io.dingodb.exec.operator.params.TxnDiskAnnStatusParam;
+import io.dingodb.exec.transaction.base.ITransaction;
+import io.dingodb.meta.MetaService;
+import io.dingodb.meta.entity.IndexTable;
+import io.dingodb.meta.entity.Table;
+import lombok.extern.slf4j.Slf4j;
+import org.apache.calcite.rex.RexNode;
+import org.apache.calcite.sql.SqlIdentifier;
+
+import java.util.ArrayList;
+import java.util.Collection;
+import java.util.List;
+import java.util.NavigableMap;
+import java.util.Objects;
+
+import static io.dingodb.exec.utils.OperatorCodeUtils.TXN_DISK_ANN_STATUS;
+
+@Slf4j
+public final class DingoDiskAnnStatusVisitFun {
+
+
+    private DingoDiskAnnStatusVisitFun() {
+
+    }
+
+    public static Collection<Vertex> visit(
+        Job job, IdGenerator idGenerator, Location currentLocation,
+        ITransaction transaction, DingoJobVisitor visitor, DingoDiskAnnStatus rel
+    ) {
+        if (transaction == null) {
+            throw new RuntimeException("not support Non-transaction");
+        }
+        DingoRelOptTable relTable = rel.getTable();
+        DingoTable dingoTable = relTable.unwrap(DingoTable.class);
+
+        MetaService metaService = MetaService.root();
+        assert dingoTable != null;
+        CommonId tableId = dingoTable.getTableId();
+        Table td = dingoTable.getTable();
+
+        NavigableMap<ComparableByteArray, RangeDistribution> ranges = metaService.getRangeDistribution(tableId);
+        List<Object> operandsList = rel.getOperands();
+        String indexName = Objects.requireNonNull((SqlIdentifier) operandsList.get(1)).toString();
+        String indexTableName = rel.getIndexTable().getName();
+        if(!indexTableName.equalsIgnoreCase(indexName)){
+            throw new IllegalArgumentException("Can not find the text index with name: " + indexName);
+        }
+
+        List<Vertex> outputs = new ArrayList<>();
+        IndexTable indexTable = (IndexTable) rel.getIndexTable();
+        RexNode rexFilter = rel.getFilter();
+        TupleMapping resultSelection = rel.getSelection();
+        long scanTs = VisitUtils.getScanTs(transaction, visitor.getKind());
+
+        SqlExpr filter = null;
+        if (rexFilter != null) {
+            filter = SqlExprUtils.toSqlExpr(rexFilter);
+        }
+        // Get all index table distributions
+        NavigableMap<ComparableByteArray, RangeDistribution> indexRanges =
+            metaService.getRangeDistribution(rel.getIndexTableId());
+
+        // Create tasks based on partitions
+        for (RangeDistribution rangeDistribution : indexRanges.values()) {
+            TxnDiskAnnStatusParam param = new TxnDiskAnnStatusParam(
+                rangeDistribution.id(),
+                Optional.mapOrNull(filter, SqlExpr::copy),
+                resultSelection,
+                rel.tupleType(),
+                td,
+                ranges,
+                indexTable,
+                scanTs,
+                transaction.getIsolationLevel(),
+                transaction.getLockTimeOut()
+                );
+            Vertex vertex = new Vertex(TXN_DISK_ANN_STATUS, param);
+            Task task = job.getOrCreate(currentLocation, idGenerator);
+            OutputHint hint = new OutputHint();
+            hint.setPartId(rangeDistribution.id());
+            vertex.setHint(hint);
+            vertex.setId(idGenerator.getOperatorId(task.getId()));
+            task.putVertex(vertex);
+            outputs.add(vertex);
+        }
+        visitor.setScan(true);
+        return outputs;
+    }
+
+}

--- a/dingo-calcite/src/main/java/org/apache/calcite/sql/validate/TableDiskAnnFunctionNamespace.java
+++ b/dingo-calcite/src/main/java/org/apache/calcite/sql/validate/TableDiskAnnFunctionNamespace.java
@@ -1,0 +1,270 @@
+/*
+ * Copyright 2021 DataCanvas
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.calcite.sql.validate;
+
+import com.google.common.collect.ImmutableList;
+import io.dingodb.calcite.DingoRelOptTable;
+import io.dingodb.calcite.DingoTable;
+import io.dingodb.calcite.runtime.DingoResource;
+import io.dingodb.common.partition.RangeDistribution;
+import io.dingodb.common.table.DiskAnnTable;
+import io.dingodb.common.type.scalar.FloatType;
+import io.dingodb.common.type.scalar.LongType;
+import io.dingodb.common.type.scalar.StringType;
+import io.dingodb.common.util.ByteArrayUtils;
+import io.dingodb.common.util.Parameters;
+import io.dingodb.meta.MetaService;
+import io.dingodb.meta.entity.Column;
+import io.dingodb.meta.entity.IndexTable;
+import io.dingodb.meta.entity.IndexType;
+import io.dingodb.meta.entity.Table;
+import lombok.Getter;
+import org.apache.calcite.rel.type.RelDataType;
+import org.apache.calcite.rel.type.RelDataTypeFactory;
+import org.apache.calcite.sql.SqlBasicCall;
+import org.apache.calcite.sql.SqlIdentifier;
+import org.apache.calcite.sql.SqlNode;
+import org.apache.calcite.sql.SqlNumericLiteral;
+import org.apache.calcite.sql2rel.SqlDiskAnnOperator;
+import org.checkerframework.checker.nullness.qual.Nullable;
+
+import java.util.ArrayList;
+import java.util.List;
+import java.util.NavigableMap;
+import java.util.Objects;
+import java.util.stream.Collectors;
+
+import static io.dingodb.calcite.type.converter.DefinitionMapper.mapToRelDataType;
+
+public class TableDiskAnnFunctionNamespace extends AbstractNamespace {
+
+    @Getter
+    private final SqlBasicCall function;
+
+    @Getter
+    private final DingoRelOptTable table;
+
+    @Getter
+    private Table index;
+
+    private SqlValidatorImpl validator;
+
+    public TableDiskAnnFunctionNamespace(SqlValidatorImpl validator, @Nullable SqlBasicCall enclosingNode) {
+        super(validator, enclosingNode);
+        assert enclosingNode != null;
+        this.validator = validator;
+        this.function = enclosingNode;
+        ImmutableList<String> tableNames = ((SqlIdentifier) this.function.operand(0)).names;
+        if (tableNames.size() < 1) {
+            throw DingoResource.DINGO_RESOURCE.invalidTableName("unknown").ex();
+        }
+        table = (DingoRelOptTable) Parameters.nonNull(
+            validator.catalogReader.getTable(tableNames),
+            () -> DingoResource.DINGO_RESOURCE.unknownTable(tableNames.get(tableNames.size() - 1)).ex()
+        );
+    }
+
+    @Override
+    protected RelDataType validateImpl(RelDataType targetRowType) {
+        DingoTable dingoTable = table.unwrap(DingoTable.class);
+        ArrayList<Column> cols = new ArrayList<>();
+
+        List<SqlNode> operandList = this.function.getOperandList();
+
+        if (function.getOperator() instanceof SqlDiskAnnOperator) {
+            if (operandList.size() < 2) {
+                throw new RuntimeException("Incorrect parameter count for disk ann vector function.");
+            }
+            SqlIdentifier columnIdentifier = (SqlIdentifier) operandList.get(1);
+            // Get all index table definition
+            Table table = dingoTable.getTable();
+
+            this.index = getVectorIndexTable(table, columnIdentifier.getSimple().toUpperCase());
+            String funcName = function.getOperator().getName();
+            if (funcName.equals(DiskAnnTable.TABLE_BUILD_NAME)) {
+                if (operandList.size() > 4 || operandList.size() < 2) {
+                    throw new RuntimeException("Incorrect parameter count for disk_ann_build function.");
+                }
+                if (operandList.size() == 4) {
+                    long reginId = ((Number) Objects.requireNonNull(((SqlNumericLiteral) operandList.get(3)).getValue())).longValue();
+                    MetaService metaService = MetaService.root();
+                    NavigableMap<ByteArrayUtils.ComparableByteArray, RangeDistribution> indexRanges =
+                        metaService.getRangeDistribution(index.tableId);
+                    boolean result = indexRanges.values().stream().anyMatch(v -> v.getId().seq == reginId);
+                    if (!result) {
+                        throw new RuntimeException("Incorrect parameter regionId for disk_ann_build function.");
+                    }
+                }
+                cols.add(Column
+                    .builder()
+                    .name(index.getName().concat("$regionId"))
+                    .sqlTypeName("BIGINT")
+                    .type(new LongType(false))
+                    .build()
+                );
+                cols.add(Column
+                    .builder()
+                    .name(index.getName().concat("$status"))
+                    .sqlTypeName("VARCHAR")
+                    .type(new StringType(false))
+                    .build()
+                );
+                RelDataTypeFactory typeFactory = validator.typeFactory;
+                rowType = typeFactory.createStructType(
+                    cols.stream().map(c -> mapToRelDataType(c, typeFactory)).collect(Collectors.toList()),
+                    cols.stream().map(Column::getName).map(String::toUpperCase).collect(Collectors.toList())
+                );
+            } else if (funcName.equals(DiskAnnTable.TABLE_LOAD_NAME)) {
+                if (operandList.size() > 5 || operandList.size() < 2) {
+                    throw new RuntimeException("Incorrect parameter count for disk_ann_load function.");
+                }
+                if (operandList.size() == 5) {
+                    long reginId = ((Number) Objects.requireNonNull(((SqlNumericLiteral) operandList.get(4)).getValue())).longValue();
+                    MetaService metaService = MetaService.root();
+                    NavigableMap<ByteArrayUtils.ComparableByteArray, RangeDistribution> indexRanges =
+                        metaService.getRangeDistribution(index.tableId);
+                    boolean result = indexRanges.values().stream().anyMatch(v -> v.getId().seq == reginId);
+                    if (!result) {
+                        throw new RuntimeException("Incorrect parameter regionId for disk_ann_load function.");
+                    }
+                }
+                cols.add(Column
+                    .builder()
+                    .name(index.getName().concat("$regionId"))
+                    .sqlTypeName("BIGINT")
+                    .type(new LongType(false))
+                    .build()
+                );
+                cols.add(Column
+                    .builder()
+                    .name(index.getName().concat("$status"))
+                    .sqlTypeName("VARCHAR")
+                    .type(new StringType(false))
+                    .build()
+                );
+                RelDataTypeFactory typeFactory = validator.typeFactory;
+                rowType = typeFactory.createStructType(
+                    cols.stream().map(c -> mapToRelDataType(c, typeFactory)).collect(Collectors.toList()),
+                    cols.stream().map(Column::getName).map(String::toUpperCase).collect(Collectors.toList())
+                );
+            } else if (funcName.equals(DiskAnnTable.TABLE_STATUS_NAME)) {
+                if (operandList.size() != 2) {
+                    throw new RuntimeException("Incorrect parameter count for disk_ann_status function.");
+                }
+                cols.add(Column
+                    .builder()
+                    .name(index.getName().concat("$regionId"))
+                    .sqlTypeName("BIGINT")
+                    .type(new LongType(false))
+                    .build()
+                );
+                cols.add(Column
+                    .builder()
+                    .name(index.getName().concat("$status"))
+                    .sqlTypeName("VARCHAR")
+                    .type(new StringType(false))
+                    .build()
+                );
+                RelDataTypeFactory typeFactory = validator.typeFactory;
+                rowType = typeFactory.createStructType(
+                    cols.stream().map(c -> mapToRelDataType(c, typeFactory)).collect(Collectors.toList()),
+                    cols.stream().map(Column::getName).map(String::toUpperCase).collect(Collectors.toList())
+                );
+            } else if (funcName.equals(DiskAnnTable.TABLE_RESET_NAME)) {
+                if (operandList.size() > 3 || operandList.size() < 2) {
+                    throw new RuntimeException("Incorrect parameter count for disk_ann_reset function.");
+                }
+                if (operandList.size() == 3) {
+                    long reginId = ((Number) Objects.requireNonNull(((SqlNumericLiteral) operandList.get(2)).getValue())).longValue();
+                    MetaService metaService = MetaService.root();
+                    NavigableMap<ByteArrayUtils.ComparableByteArray, RangeDistribution> indexRanges =
+                        metaService.getRangeDistribution(index.tableId);
+                    boolean result = indexRanges.values().stream().anyMatch(v -> v.getId().seq == reginId);
+                    if (!result) {
+                        throw new RuntimeException("Incorrect parameter regionId for disk_ann_reset function.");
+                    }
+                }
+                cols.add(Column
+                    .builder()
+                    .name(index.getName().concat("$regionId"))
+                    .sqlTypeName("BIGINT")
+                    .type(new LongType(false))
+                    .build()
+                );
+                cols.add(Column
+                    .builder()
+                    .name(index.getName().concat("$status"))
+                    .sqlTypeName("VARCHAR")
+                    .type(new StringType(false))
+                    .build()
+                );
+                RelDataTypeFactory typeFactory = validator.typeFactory;
+                rowType = typeFactory.createStructType(
+                    cols.stream().map(c -> mapToRelDataType(c, typeFactory)).collect(Collectors.toList()),
+                    cols.stream().map(Column::getName).map(String::toUpperCase).collect(Collectors.toList())
+                );
+            } else if (funcName.equals(DiskAnnTable.TABLE_COUNT_MEMORY_NAME)) {
+                if (operandList.size() != 2) {
+                    throw new RuntimeException("Incorrect parameter count for disk_ann_count_memory function.");
+                }
+                cols.add(Column
+                    .builder()
+                    .name(index.getName().concat("$regionId"))
+                    .sqlTypeName("BIGINT")
+                    .type(new LongType(false))
+                    .build()
+                );
+                cols.add(Column
+                    .builder()
+                    .name(index.getName().concat("$count"))
+                    .sqlTypeName("BIGINT")
+                    .type(new LongType(false))
+                    .build()
+                );
+                RelDataTypeFactory typeFactory = validator.typeFactory;
+                rowType = typeFactory.createStructType(
+                    cols.stream().map(c -> mapToRelDataType(c, typeFactory)).collect(Collectors.toList()),
+                    cols.stream().map(Column::getName).map(String::toUpperCase).collect(Collectors.toList())
+                );
+            } else {
+                throw new RuntimeException("unsupported operator type.");
+            }
+            return rowType;
+        } else {
+            throw new RuntimeException("unsupported operator type.");
+        }
+
+    }
+
+    @Override
+    public @Nullable SqlNode getNode() {
+        return function;
+    }
+
+    public static IndexTable getVectorIndexTable(Table table, String vectorColName) {
+        for (IndexTable index : table.getIndexes()) {
+            if (!index.getIndexType().isVector || index.indexType != IndexType.VECTOR_DISKANN ||
+                !vectorColName.equalsIgnoreCase(index.getName())) {
+                continue;
+            }
+
+            return index;
+        }
+        throw new RuntimeException(vectorColName + " disk ann vector not found.");
+    }
+
+}

--- a/dingo-calcite/src/main/java/org/apache/calcite/sql2rel/SqlDiskAnnOperator.java
+++ b/dingo-calcite/src/main/java/org/apache/calcite/sql2rel/SqlDiskAnnOperator.java
@@ -1,0 +1,104 @@
+/*
+ * Copyright 2021 DataCanvas
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.calcite.sql2rel;
+
+import io.dingodb.calcite.DingoParserContext;
+import io.dingodb.calcite.grammar.SqlUserDefinedOperators;
+import org.apache.calcite.rel.type.RelDataType;
+import org.apache.calcite.rel.type.RelDataTypeFactory;
+import org.apache.calcite.rex.RexBuilder;
+import org.apache.calcite.schema.TranslatableTable;
+import org.apache.calcite.sql.SqlFunction;
+import org.apache.calcite.sql.SqlFunctionCategory;
+import org.apache.calcite.sql.SqlKind;
+import org.apache.calcite.sql.SqlOperatorBinding;
+import org.apache.calcite.sql.SqlTableFunction;
+import org.apache.calcite.sql.type.InferTypes;
+import org.apache.calcite.sql.type.OperandTypes;
+import org.apache.calcite.sql.type.ReturnTypes;
+import org.apache.calcite.sql.type.SqlReturnTypeInference;
+import org.apache.calcite.sql.validate.TableDiskAnnFunctionNamespace;
+import org.apache.calcite.sql.validate.TableHybridFunctionNamespace;
+
+import java.util.Collections;
+
+public class SqlDiskAnnOperator extends SqlFunction implements SqlTableFunction {
+
+    public static void register(DingoParserContext context) {
+        StandardConvertletTable.INSTANCE.registerOp(SqlUserDefinedOperators.DISK_ANN_BUILD,
+            (cx, call) -> {
+                RexBuilder rexBuilder = cx.getRexBuilder();
+                TableDiskAnnFunctionNamespace namespace = (TableDiskAnnFunctionNamespace) cx.getValidator().getNamespace(call);
+                return  rexBuilder.makeCall(namespace.getRowType(), call.getOperator(), Collections.EMPTY_LIST);
+            });
+        StandardConvertletTable.INSTANCE.registerOp(SqlUserDefinedOperators.DISK_ANN_LOAD,
+            (cx, call) -> {
+                RexBuilder rexBuilder = cx.getRexBuilder();
+                TableDiskAnnFunctionNamespace namespace = (TableDiskAnnFunctionNamespace) cx.getValidator().getNamespace(call);
+                return  rexBuilder.makeCall(namespace.getRowType(), call.getOperator(), Collections.EMPTY_LIST);
+            });
+        StandardConvertletTable.INSTANCE.registerOp(SqlUserDefinedOperators.DISK_ANN_STATUS,
+            (cx, call) -> {
+                RexBuilder rexBuilder = cx.getRexBuilder();
+                TableDiskAnnFunctionNamespace namespace = (TableDiskAnnFunctionNamespace) cx.getValidator().getNamespace(call);
+                return  rexBuilder.makeCall(namespace.getRowType(), call.getOperator(), Collections.EMPTY_LIST);
+            });
+        StandardConvertletTable.INSTANCE.registerOp(SqlUserDefinedOperators.DISK_ANN_RESET,
+            (cx, call) -> {
+                RexBuilder rexBuilder = cx.getRexBuilder();
+                TableDiskAnnFunctionNamespace namespace = (TableDiskAnnFunctionNamespace) cx.getValidator().getNamespace(call);
+                return  rexBuilder.makeCall(namespace.getRowType(), call.getOperator(), Collections.EMPTY_LIST);
+            });
+        StandardConvertletTable.INSTANCE.registerOp(SqlUserDefinedOperators.DISK_ANN_COUNT_MEMORY,
+            (cx, call) -> {
+                RexBuilder rexBuilder = cx.getRexBuilder();
+                TableDiskAnnFunctionNamespace namespace = (TableDiskAnnFunctionNamespace) cx.getValidator().getNamespace(call);
+                return  rexBuilder.makeCall(namespace.getRowType(), call.getOperator(), Collections.EMPTY_LIST);
+            });
+    }
+
+    /**
+     * Creates a SqlHybridSearchOperator.
+     *
+     * @param name        Operator name
+     */
+    public SqlDiskAnnOperator(String name, SqlKind kind) {
+        super(
+            name,
+            kind,
+            ReturnTypes.ARG0,
+            InferTypes.VARCHAR_1024,
+            OperandTypes.CURSOR,
+            SqlFunctionCategory.USER_DEFINED_TABLE_FUNCTION
+        );
+    }
+
+    @Override
+    public SqlReturnTypeInference getRowTypeInference() {
+        return this::inferRowType;
+    }
+
+    private RelDataType inferRowType(SqlOperatorBinding callBinding) {
+        final RelDataTypeFactory typeFactory = callBinding.getTypeFactory();
+        final TranslatableTable table = getTable(null, null);
+        return table.getRowType(typeFactory);
+    }
+
+    private TranslatableTable getTable(DingoParserContext context, String tableName) {
+        return (TranslatableTable) context.getDefaultSchema().getTable(tableName, false).getTable();
+    }
+}

--- a/dingo-common/src/main/java/io/dingodb/common/table/DiskAnnTable.java
+++ b/dingo-common/src/main/java/io/dingodb/common/table/DiskAnnTable.java
@@ -1,0 +1,31 @@
+/*
+ * Copyright 2021 DataCanvas
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package io.dingodb.common.table;
+
+public class DiskAnnTable {
+
+    public final static String TABLE_BUILD_NAME = "DISK_ANN_BUILD";
+
+    public final static String TABLE_LOAD_NAME = "DISK_ANN_LOAD";
+
+    public final static String TABLE_STATUS_NAME = "DISK_ANN_STATUS";
+
+    public final static String TABLE_RESET_NAME = "DISK_ANN_RESET";
+
+    public final static String TABLE_COUNT_MEMORY_NAME = "DISK_ANN_COUNT_MEMORY";
+
+}

--- a/dingo-driver/host/src/main/java/io/dingodb/driver/DingoDriverParser.java
+++ b/dingo-driver/host/src/main/java/io/dingodb/driver/DingoDriverParser.java
@@ -34,6 +34,11 @@ import io.dingodb.calcite.grammar.ddl.SqlRollback;
 import io.dingodb.calcite.meta.DingoColumnMetaData;
 import io.dingodb.calcite.rel.AutoIncrementShuttle;
 import io.dingodb.calcite.rel.DingoBasicCall;
+import io.dingodb.calcite.rel.DingoDiskAnnBuild;
+import io.dingodb.calcite.rel.DingoDiskAnnCountMemory;
+import io.dingodb.calcite.rel.DingoDiskAnnLoad;
+import io.dingodb.calcite.rel.DingoDiskAnnReset;
+import io.dingodb.calcite.rel.DingoDiskAnnStatus;
 import io.dingodb.calcite.rel.DingoDocument;
 import io.dingodb.calcite.rel.DingoVector;
 import io.dingodb.calcite.type.converter.DefinitionMapper;
@@ -786,7 +791,10 @@ public final class DingoDriverParser extends DingoParser {
         RelShuttleImpl relShuttle = new RelShuttleImpl() {
             @Override
             public RelNode visit(RelNode other) {
-                if (other instanceof DingoVector || other instanceof  DingoDocument) {
+                if (other instanceof DingoVector || other instanceof DingoDocument ||
+                    other instanceof DingoDiskAnnStatus || other instanceof DingoDiskAnnCountMemory ||
+                    other instanceof DingoDiskAnnReset || other instanceof DingoDiskAnnBuild ||
+                    other instanceof DingoDiskAnnLoad) {
                     return other;
                 }
                 if (!other.getInputs().isEmpty()) {
@@ -812,6 +820,16 @@ public final class DingoDriverParser extends DingoParser {
                     return child2;
                 } else if (child2 instanceof DingoDocument) {
                     return child2;
+                } else if (child2 instanceof DingoDiskAnnBuild) {
+                    return child2;
+                } else if (child2 instanceof DingoDiskAnnLoad) {
+                    return child2;
+                } else if (child2 instanceof DingoDiskAnnStatus) {
+                    return child2;
+                } else if (child2 instanceof DingoDiskAnnCountMemory) {
+                    return child2;
+                } else if (child2 instanceof DingoDiskAnnReset) {
+                    return child2;
                 }
                 return null;
             }
@@ -823,6 +841,21 @@ public final class DingoDriverParser extends DingoParser {
         } else if (relNode1 instanceof DingoDocument) {
             DingoDocument document = (DingoDocument) relNode1;
             return document.getTable();
+        } else if(relNode1 instanceof DingoDiskAnnBuild){
+            DingoDiskAnnBuild dingoDiskAnnBuild = (DingoDiskAnnBuild) relNode1;
+            return dingoDiskAnnBuild.getTable();
+        } else if(relNode1 instanceof DingoDiskAnnLoad){
+            DingoDiskAnnLoad dingoDiskAnnLoad = (DingoDiskAnnLoad) relNode1;
+            return dingoDiskAnnLoad.getTable();
+        } else if(relNode1 instanceof DingoDiskAnnStatus){
+            DingoDiskAnnStatus diskAnnStatus = (DingoDiskAnnStatus) relNode1;
+            return diskAnnStatus.getTable();
+        } else if(relNode1 instanceof DingoDiskAnnCountMemory){
+            DingoDiskAnnCountMemory diskAnnCountMemory = (DingoDiskAnnCountMemory) relNode1;
+            return diskAnnCountMemory.getTable();
+        } else if(relNode1 instanceof DingoDiskAnnReset){
+            DingoDiskAnnReset dingoDiskAnnReset = (DingoDiskAnnReset) relNode1;
+            return dingoDiskAnnReset.getTable();
         }
         return null;
     }

--- a/dingo-exec/src/main/java/io/dingodb/exec/OperatorFactory.java
+++ b/dingo-exec/src/main/java/io/dingodb/exec/OperatorFactory.java
@@ -64,6 +64,11 @@ import io.dingodb.exec.operator.ScanWithPipeOpOperator;
 import io.dingodb.exec.operator.SendOperator;
 import io.dingodb.exec.operator.SortOperator;
 import io.dingodb.exec.operator.SumUpOperator;
+import io.dingodb.exec.operator.TxnDiskAnnBuildOperator;
+import io.dingodb.exec.operator.TxnDiskAnnCountMemoryOperator;
+import io.dingodb.exec.operator.TxnDiskAnnLoadOperator;
+import io.dingodb.exec.operator.TxnDiskAnnResetOperator;
+import io.dingodb.exec.operator.TxnDiskAnnStatusOperator;
 import io.dingodb.exec.operator.TxnGetByIndexOperator;
 import io.dingodb.exec.operator.TxnGetByKeysOperator;
 import io.dingodb.exec.operator.TxnIndexRangeScanOperator;
@@ -148,6 +153,11 @@ import static io.dingodb.exec.utils.OperatorCodeUtils.SORT;
 import static io.dingodb.exec.utils.OperatorCodeUtils.SUM_UP;
 import static io.dingodb.exec.utils.OperatorCodeUtils.TXN_CLEAN_CACHE;
 import static io.dingodb.exec.utils.OperatorCodeUtils.TXN_CLEAN_EXTRA_DATA_CACHE;
+import static io.dingodb.exec.utils.OperatorCodeUtils.TXN_DISK_ANN_BUILD;
+import static io.dingodb.exec.utils.OperatorCodeUtils.TXN_DISK_ANN_COUNT_MEMORY;
+import static io.dingodb.exec.utils.OperatorCodeUtils.TXN_DISK_ANN_LOAD;
+import static io.dingodb.exec.utils.OperatorCodeUtils.TXN_DISK_ANN_RESET;
+import static io.dingodb.exec.utils.OperatorCodeUtils.TXN_DISK_ANN_STATUS;
 import static io.dingodb.exec.utils.OperatorCodeUtils.TXN_GET_BY_INDEX;
 import static io.dingodb.exec.utils.OperatorCodeUtils.TXN_GET_BY_KEYS;
 import static io.dingodb.exec.utils.OperatorCodeUtils.TXN_INDEX_RANGE_SCAN;
@@ -244,6 +254,11 @@ public final class OperatorFactory {
         OPERATORS.put(TXN_PART_DOCUMENT, TxnPartDocumentOperator.INSTANCE);
         OPERATORS.put(DOCUMENT_PRE_FILTER, DocumentPreFilterOperator.INSTANCE);
         OPERATORS.put(TXN_CLEAN_EXTRA_DATA_CACHE, CleanExtraDataCacheOperator.INSTANCE);
+        OPERATORS.put(TXN_DISK_ANN_STATUS, TxnDiskAnnStatusOperator.INSTANCE);
+        OPERATORS.put(TXN_DISK_ANN_COUNT_MEMORY, TxnDiskAnnCountMemoryOperator.INSTANCE);
+        OPERATORS.put(TXN_DISK_ANN_RESET, TxnDiskAnnResetOperator.INSTANCE);
+        OPERATORS.put(TXN_DISK_ANN_BUILD, TxnDiskAnnBuildOperator.INSTANCE);
+        OPERATORS.put(TXN_DISK_ANN_LOAD, TxnDiskAnnLoadOperator.INSTANCE);
     }
 
     private OperatorFactory() {

--- a/dingo-exec/src/main/java/io/dingodb/exec/operator/TxnDiskAnnBuildOperator.java
+++ b/dingo-exec/src/main/java/io/dingodb/exec/operator/TxnDiskAnnBuildOperator.java
@@ -1,0 +1,52 @@
+/*
+ * Copyright 2021 DataCanvas
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package io.dingodb.exec.operator;
+
+import io.dingodb.common.profile.OperatorProfile;
+import io.dingodb.exec.Services;
+import io.dingodb.exec.dag.Vertex;
+import io.dingodb.exec.operator.params.TxnDiskAnnBuildParam;
+import io.dingodb.store.api.StoreInstance;
+import lombok.extern.slf4j.Slf4j;
+import org.checkerframework.checker.nullness.qual.NonNull;
+
+import java.util.ArrayList;
+import java.util.Iterator;
+import java.util.List;
+
+@Slf4j
+public class TxnDiskAnnBuildOperator extends FilterProjectSourceOperator {
+
+    public static final TxnDiskAnnBuildOperator INSTANCE = new TxnDiskAnnBuildOperator();
+
+    @Override
+    protected @NonNull Iterator<Object[]> createSourceIterator(Vertex vertex) {
+        TxnDiskAnnBuildParam param = vertex.getParam();
+        OperatorProfile profile = param.getProfile("diskAnnBuild");
+        long start = System.currentTimeMillis();
+        StoreInstance instance = Services.KV_STORE.getInstance(param.getTableId(), param.getPartId());
+        String diskAnnResetStatus = instance.diskAnnBuild(param.getScanTs(), param.getIndexId(), param.getTs());
+        List<Object[]> results = new ArrayList<>();
+        Object[] priTuples = new Object[2];
+        priTuples[0] = param.getPartId().seq;
+        priTuples[1] = diskAnnResetStatus;
+        results.add(priTuples);
+        profile.incrTime(start);
+        return results.iterator();
+    }
+
+}

--- a/dingo-exec/src/main/java/io/dingodb/exec/operator/TxnDiskAnnCountMemoryOperator.java
+++ b/dingo-exec/src/main/java/io/dingodb/exec/operator/TxnDiskAnnCountMemoryOperator.java
@@ -1,0 +1,52 @@
+/*
+ * Copyright 2021 DataCanvas
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package io.dingodb.exec.operator;
+
+import io.dingodb.common.profile.OperatorProfile;
+import io.dingodb.exec.Services;
+import io.dingodb.exec.dag.Vertex;
+import io.dingodb.exec.operator.params.TxnDiskAnnCountMemoryParam;
+import io.dingodb.store.api.StoreInstance;
+import lombok.extern.slf4j.Slf4j;
+import org.checkerframework.checker.nullness.qual.NonNull;
+
+import java.util.ArrayList;
+import java.util.Iterator;
+import java.util.List;
+
+@Slf4j
+public class TxnDiskAnnCountMemoryOperator extends FilterProjectSourceOperator {
+
+    public static final TxnDiskAnnCountMemoryOperator INSTANCE = new TxnDiskAnnCountMemoryOperator();
+
+    @Override
+    protected @NonNull Iterator<Object[]> createSourceIterator(Vertex vertex) {
+        TxnDiskAnnCountMemoryParam param = vertex.getParam();
+        OperatorProfile profile = param.getProfile("diskAnnCountMemory");
+        long start = System.currentTimeMillis();
+        StoreInstance instance = Services.KV_STORE.getInstance(param.getTableId(), param.getPartId());
+        long count = instance.diskAnnCountMemory(param.getScanTs(), param.getIndexId());
+        List<Object[]> results = new ArrayList<>();
+        Object[] priTuples = new Object[2];
+        priTuples[0] = param.getPartId().seq;
+        priTuples[1] = count;
+        results.add(priTuples);
+        profile.incrTime(start);
+        return results.iterator();
+    }
+
+}

--- a/dingo-exec/src/main/java/io/dingodb/exec/operator/TxnDiskAnnLoadOperator.java
+++ b/dingo-exec/src/main/java/io/dingodb/exec/operator/TxnDiskAnnLoadOperator.java
@@ -1,0 +1,52 @@
+/*
+ * Copyright 2021 DataCanvas
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package io.dingodb.exec.operator;
+
+import io.dingodb.common.profile.OperatorProfile;
+import io.dingodb.exec.Services;
+import io.dingodb.exec.dag.Vertex;
+import io.dingodb.exec.operator.params.TxnDiskAnnLoadParam;
+import io.dingodb.store.api.StoreInstance;
+import lombok.extern.slf4j.Slf4j;
+import org.checkerframework.checker.nullness.qual.NonNull;
+
+import java.util.ArrayList;
+import java.util.Iterator;
+import java.util.List;
+
+@Slf4j
+public class TxnDiskAnnLoadOperator extends FilterProjectSourceOperator {
+
+    public static final TxnDiskAnnLoadOperator INSTANCE = new TxnDiskAnnLoadOperator();
+
+    @Override
+    protected @NonNull Iterator<Object[]> createSourceIterator(Vertex vertex) {
+        TxnDiskAnnLoadParam param = vertex.getParam();
+        OperatorProfile profile = param.getProfile("diskAnnLoad");
+        long start = System.currentTimeMillis();
+        StoreInstance instance = Services.KV_STORE.getInstance(param.getTableId(), param.getPartId());
+        String diskAnnResetStatus = instance.diskAnnLoad(param.getScanTs(), param.getIndexId(), param.getNodesCacheNum(), param.isWarmup());
+        List<Object[]> results = new ArrayList<>();
+        Object[] priTuples = new Object[2];
+        priTuples[0] = param.getPartId().seq;
+        priTuples[1] = diskAnnResetStatus;
+        results.add(priTuples);
+        profile.incrTime(start);
+        return results.iterator();
+    }
+
+}

--- a/dingo-exec/src/main/java/io/dingodb/exec/operator/TxnDiskAnnResetOperator.java
+++ b/dingo-exec/src/main/java/io/dingodb/exec/operator/TxnDiskAnnResetOperator.java
@@ -1,0 +1,52 @@
+/*
+ * Copyright 2021 DataCanvas
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package io.dingodb.exec.operator;
+
+import io.dingodb.common.profile.OperatorProfile;
+import io.dingodb.exec.Services;
+import io.dingodb.exec.dag.Vertex;
+import io.dingodb.exec.operator.params.TxnDiskAnnResetParam;
+import io.dingodb.store.api.StoreInstance;
+import lombok.extern.slf4j.Slf4j;
+import org.checkerframework.checker.nullness.qual.NonNull;
+
+import java.util.ArrayList;
+import java.util.Iterator;
+import java.util.List;
+
+@Slf4j
+public class TxnDiskAnnResetOperator extends FilterProjectSourceOperator {
+
+    public static final TxnDiskAnnResetOperator INSTANCE = new TxnDiskAnnResetOperator();
+
+    @Override
+    protected @NonNull Iterator<Object[]> createSourceIterator(Vertex vertex) {
+        TxnDiskAnnResetParam param = vertex.getParam();
+        OperatorProfile profile = param.getProfile("diskAnnReset");
+        long start = System.currentTimeMillis();
+        StoreInstance instance = Services.KV_STORE.getInstance(param.getTableId(), param.getPartId());
+        String diskAnnResetStatus = instance.diskAnnReset(param.getScanTs(), param.getIndexId());
+        List<Object[]> results = new ArrayList<>();
+        Object[] priTuples = new Object[2];
+        priTuples[0] = param.getPartId().seq;
+        priTuples[1] = diskAnnResetStatus;
+        results.add(priTuples);
+        profile.incrTime(start);
+        return results.iterator();
+    }
+
+}

--- a/dingo-exec/src/main/java/io/dingodb/exec/operator/TxnDiskAnnStatusOperator.java
+++ b/dingo-exec/src/main/java/io/dingodb/exec/operator/TxnDiskAnnStatusOperator.java
@@ -1,0 +1,53 @@
+/*
+ * Copyright 2021 DataCanvas
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package io.dingodb.exec.operator;
+
+import io.dingodb.common.profile.OperatorProfile;
+import io.dingodb.common.util.Pair;
+import io.dingodb.exec.Services;
+import io.dingodb.exec.dag.Vertex;
+import io.dingodb.exec.operator.params.TxnDiskAnnStatusParam;
+import io.dingodb.store.api.StoreInstance;
+import lombok.extern.slf4j.Slf4j;
+import org.checkerframework.checker.nullness.qual.NonNull;
+
+import java.util.ArrayList;
+import java.util.Iterator;
+import java.util.List;
+
+@Slf4j
+public class TxnDiskAnnStatusOperator extends FilterProjectSourceOperator {
+
+    public static final TxnDiskAnnStatusOperator INSTANCE = new TxnDiskAnnStatusOperator();
+
+    @Override
+    protected @NonNull Iterator<Object[]> createSourceIterator(Vertex vertex) {
+        TxnDiskAnnStatusParam param = vertex.getParam();
+        OperatorProfile profile = param.getProfile("diskAnnStatus");
+        long start = System.currentTimeMillis();
+        StoreInstance instance = Services.KV_STORE.getInstance(param.getTableId(), param.getPartId());
+        String diskAnnStatus = instance.diskAnnStatus(param.getScanTs(), param.getIndexId());
+        List<Object[]> results = new ArrayList<>();
+        Object[] priTuples = new Object[2];
+        priTuples[0] = param.getPartId().seq;
+        priTuples[1] = diskAnnStatus;
+        results.add(priTuples);
+        profile.incrTime(start);
+        return results.iterator();
+    }
+
+}

--- a/dingo-exec/src/main/java/io/dingodb/exec/operator/TxnPartVectorOperator.java
+++ b/dingo-exec/src/main/java/io/dingodb/exec/operator/TxnPartVectorOperator.java
@@ -72,7 +72,9 @@ public class TxnPartVectorOperator extends FilterProjectSourceOperator {
             param.getFloatArray(),
             param.getTopN(),
             param.getParameterMap(),
-            param.getCoprocessor());
+            param.getCoprocessor(),
+            param.isDiskAnnVector()
+        );
         List<Object[]> results = new ArrayList<>();
         if (param.isLookUp()) {
             Map<Integer, Integer> vecPriIdxMapping = getVecPriIdxMapping(param);

--- a/dingo-exec/src/main/java/io/dingodb/exec/operator/params/AbstractParams.java
+++ b/dingo-exec/src/main/java/io/dingodb/exec/operator/params/AbstractParams.java
@@ -119,7 +119,10 @@ import lombok.Setter;
     @JsonSubTypes.Type(TxnPartDocumentParam.class),
     @JsonSubTypes.Type(ScanCleanExtraDataCacheParam.class),
     @JsonSubTypes.Type(CleanExtraDataCacheParam.class),
-    @JsonSubTypes.Type(DocumentPreFilterParam.class)
+    @JsonSubTypes.Type(DocumentPreFilterParam.class),
+    @JsonSubTypes.Type(TxnDiskAnnStatusParam.class),
+    @JsonSubTypes.Type(TxnDiskAnnCountMemoryParam.class),
+    @JsonSubTypes.Type(TxnDiskAnnResetParam.class)
 })
 @JsonInclude(JsonInclude.Include.NON_NULL)
 public abstract class AbstractParams {

--- a/dingo-exec/src/main/java/io/dingodb/exec/operator/params/TxnDiskAnnBuildParam.java
+++ b/dingo-exec/src/main/java/io/dingodb/exec/operator/params/TxnDiskAnnBuildParam.java
@@ -1,0 +1,97 @@
+/*
+ * Copyright 2021 DataCanvas
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package io.dingodb.exec.operator.params;
+
+import com.fasterxml.jackson.annotation.JsonProperty;
+import com.fasterxml.jackson.annotation.JsonPropertyOrder;
+import com.fasterxml.jackson.annotation.JsonTypeName;
+import io.dingodb.codec.CodecService;
+import io.dingodb.codec.KeyValueCodec;
+import io.dingodb.common.CommonId;
+import io.dingodb.common.partition.RangeDistribution;
+import io.dingodb.common.type.DingoType;
+import io.dingodb.common.type.TupleMapping;
+import io.dingodb.common.util.ByteArrayUtils;
+import io.dingodb.exec.dag.Vertex;
+import io.dingodb.exec.expr.SqlExpr;
+import io.dingodb.meta.entity.IndexTable;
+import io.dingodb.meta.entity.Table;
+import lombok.Getter;
+
+import java.util.NavigableMap;
+
+@Getter
+@JsonTypeName("txn_diskAnnBuild")
+@JsonPropertyOrder({
+    "tableId", "part", "schema", "keyMapping", "filter", "selection", "indexId", "indexRegionId", "ts"
+})
+public class TxnDiskAnnBuildParam extends FilterProjectSourceParam {
+    private KeyValueCodec codec;
+    private final Table table;
+
+    private final NavigableMap<ByteArrayUtils.ComparableByteArray, RangeDistribution> distributions;
+    private final CommonId indexId;
+    private final IndexTable indexTable;
+    @JsonProperty("scanTs")
+    private long scanTs;
+    @JsonProperty("filter")
+    protected SqlExpr filter;
+    @JsonProperty("isolationLevel")
+    private final int isolationLevel;
+    @JsonProperty("timeOut")
+    private final long timeOut;
+    @JsonProperty("selection")
+    protected TupleMapping selection;
+    @JsonProperty("ts")
+    private final long ts;
+
+    public TxnDiskAnnBuildParam(
+        CommonId partId,
+        SqlExpr filter,
+        TupleMapping selection,
+        DingoType schema,
+        Table table,
+        NavigableMap<ByteArrayUtils.ComparableByteArray, RangeDistribution> distributions,
+        Table indexTable,
+        long scanTs,
+        int isolationLevel,
+        long timeOut,
+        long ts
+    ) {
+        super(table.tableId, partId, schema, table.version, filter, selection, table.keyMapping());
+        this.table = table;
+        this.distributions = distributions;
+        this.indexId = indexTable.tableId;
+        this.indexTable = (IndexTable) indexTable;
+        this.scanTs = scanTs;
+        this.isolationLevel = isolationLevel;
+        this.timeOut = timeOut;
+        this.ts = ts;
+    }
+
+    @Override
+    public void init(Vertex vertex) {
+        super.init(vertex);
+        codec = CodecService.getDefault().createKeyValueCodec(schemaVersion, schema, keyMapping);
+    }
+
+    @Override
+    public void setStartTs(long startTs) {
+        this.scanTs = startTs;
+    }
+
+}

--- a/dingo-exec/src/main/java/io/dingodb/exec/operator/params/TxnDiskAnnCountMemoryParam.java
+++ b/dingo-exec/src/main/java/io/dingodb/exec/operator/params/TxnDiskAnnCountMemoryParam.java
@@ -1,0 +1,93 @@
+/*
+ * Copyright 2021 DataCanvas
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package io.dingodb.exec.operator.params;
+
+import com.fasterxml.jackson.annotation.JsonProperty;
+import com.fasterxml.jackson.annotation.JsonPropertyOrder;
+import com.fasterxml.jackson.annotation.JsonTypeName;
+import io.dingodb.codec.CodecService;
+import io.dingodb.codec.KeyValueCodec;
+import io.dingodb.common.CommonId;
+import io.dingodb.common.partition.RangeDistribution;
+import io.dingodb.common.type.DingoType;
+import io.dingodb.common.type.TupleMapping;
+import io.dingodb.common.util.ByteArrayUtils;
+import io.dingodb.exec.dag.Vertex;
+import io.dingodb.exec.expr.SqlExpr;
+import io.dingodb.meta.entity.IndexTable;
+import io.dingodb.meta.entity.Table;
+import lombok.Getter;
+
+import java.util.NavigableMap;
+
+@Getter
+@JsonTypeName("txn_countMemory")
+@JsonPropertyOrder({
+    "tableId", "part", "schema", "keyMapping", "filter", "selection", "indexId", "indexRegionId"
+})
+public class TxnDiskAnnCountMemoryParam extends FilterProjectSourceParam {
+    private KeyValueCodec codec;
+    private final Table table;
+
+    private final NavigableMap<ByteArrayUtils.ComparableByteArray, RangeDistribution> distributions;
+    private final CommonId indexId;
+    private final IndexTable indexTable;
+    @JsonProperty("scanTs")
+    private long scanTs;
+    @JsonProperty("filter")
+    protected SqlExpr filter;
+    @JsonProperty("isolationLevel")
+    private final int isolationLevel;
+    @JsonProperty("timeOut")
+    private final long timeOut;
+    @JsonProperty("selection")
+    protected TupleMapping selection;
+
+    public TxnDiskAnnCountMemoryParam(
+        CommonId partId,
+        SqlExpr filter,
+        TupleMapping selection,
+        DingoType schema,
+        Table table,
+        NavigableMap<ByteArrayUtils.ComparableByteArray, RangeDistribution> distributions,
+        Table indexTable,
+        long scanTs,
+        int isolationLevel,
+        long timeOut
+    ) {
+        super(table.tableId, partId, schema, table.version, filter, selection, table.keyMapping());
+        this.table = table;
+        this.distributions = distributions;
+        this.indexId = indexTable.tableId;
+        this.indexTable = (IndexTable) indexTable;
+        this.scanTs = scanTs;
+        this.isolationLevel = isolationLevel;
+        this.timeOut = timeOut;
+    }
+
+    @Override
+    public void init(Vertex vertex) {
+        super.init(vertex);
+        codec = CodecService.getDefault().createKeyValueCodec(schemaVersion, schema, keyMapping);
+    }
+
+    @Override
+    public void setStartTs(long startTs) {
+        this.scanTs = startTs;
+    }
+
+}

--- a/dingo-exec/src/main/java/io/dingodb/exec/operator/params/TxnDiskAnnLoadParam.java
+++ b/dingo-exec/src/main/java/io/dingodb/exec/operator/params/TxnDiskAnnLoadParam.java
@@ -1,0 +1,102 @@
+/*
+ * Copyright 2021 DataCanvas
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package io.dingodb.exec.operator.params;
+
+import com.fasterxml.jackson.annotation.JsonProperty;
+import com.fasterxml.jackson.annotation.JsonPropertyOrder;
+import com.fasterxml.jackson.annotation.JsonTypeName;
+import io.dingodb.codec.CodecService;
+import io.dingodb.codec.KeyValueCodec;
+import io.dingodb.common.CommonId;
+import io.dingodb.common.partition.RangeDistribution;
+import io.dingodb.common.type.DingoType;
+import io.dingodb.common.type.TupleMapping;
+import io.dingodb.common.util.ByteArrayUtils;
+import io.dingodb.exec.dag.Vertex;
+import io.dingodb.exec.expr.SqlExpr;
+import io.dingodb.meta.entity.IndexTable;
+import io.dingodb.meta.entity.Table;
+import lombok.Getter;
+
+import java.util.NavigableMap;
+
+@Getter
+@JsonTypeName("txn_diskAnnLoad")
+@JsonPropertyOrder({
+    "tableId", "part", "schema", "keyMapping", "filter",
+    "selection", "indexId", "indexRegionId", "nodesCacheNum", "warmup"
+})
+public class TxnDiskAnnLoadParam extends FilterProjectSourceParam {
+    private KeyValueCodec codec;
+    private final Table table;
+
+    private final NavigableMap<ByteArrayUtils.ComparableByteArray, RangeDistribution> distributions;
+    private final CommonId indexId;
+    private final IndexTable indexTable;
+    @JsonProperty("scanTs")
+    private long scanTs;
+    @JsonProperty("filter")
+    protected SqlExpr filter;
+    @JsonProperty("isolationLevel")
+    private final int isolationLevel;
+    @JsonProperty("timeOut")
+    private final long timeOut;
+    @JsonProperty("selection")
+    protected TupleMapping selection;
+    @JsonProperty("nodesCacheNum")
+    private final int nodesCacheNum;
+    @JsonProperty("warmup")
+    private final boolean warmup;
+
+    public TxnDiskAnnLoadParam(
+        CommonId partId,
+        SqlExpr filter,
+        TupleMapping selection,
+        DingoType schema,
+        Table table,
+        NavigableMap<ByteArrayUtils.ComparableByteArray, RangeDistribution> distributions,
+        Table indexTable,
+        long scanTs,
+        int isolationLevel,
+        long timeOut,
+        int nodesCacheNum,
+        boolean warmup
+    ) {
+        super(table.tableId, partId, schema, table.version, filter, selection, table.keyMapping());
+        this.table = table;
+        this.distributions = distributions;
+        this.indexId = indexTable.tableId;
+        this.indexTable = (IndexTable) indexTable;
+        this.scanTs = scanTs;
+        this.isolationLevel = isolationLevel;
+        this.timeOut = timeOut;
+        this.nodesCacheNum = nodesCacheNum;
+        this.warmup = warmup;
+    }
+
+    @Override
+    public void init(Vertex vertex) {
+        super.init(vertex);
+        codec = CodecService.getDefault().createKeyValueCodec(schemaVersion, schema, keyMapping);
+    }
+
+    @Override
+    public void setStartTs(long startTs) {
+        this.scanTs = startTs;
+    }
+
+}

--- a/dingo-exec/src/main/java/io/dingodb/exec/operator/params/TxnDiskAnnResetParam.java
+++ b/dingo-exec/src/main/java/io/dingodb/exec/operator/params/TxnDiskAnnResetParam.java
@@ -1,0 +1,93 @@
+/*
+ * Copyright 2021 DataCanvas
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package io.dingodb.exec.operator.params;
+
+import com.fasterxml.jackson.annotation.JsonProperty;
+import com.fasterxml.jackson.annotation.JsonPropertyOrder;
+import com.fasterxml.jackson.annotation.JsonTypeName;
+import io.dingodb.codec.CodecService;
+import io.dingodb.codec.KeyValueCodec;
+import io.dingodb.common.CommonId;
+import io.dingodb.common.partition.RangeDistribution;
+import io.dingodb.common.type.DingoType;
+import io.dingodb.common.type.TupleMapping;
+import io.dingodb.common.util.ByteArrayUtils;
+import io.dingodb.exec.dag.Vertex;
+import io.dingodb.exec.expr.SqlExpr;
+import io.dingodb.meta.entity.IndexTable;
+import io.dingodb.meta.entity.Table;
+import lombok.Getter;
+
+import java.util.NavigableMap;
+
+@Getter
+@JsonTypeName("txn_diskAnnReset")
+@JsonPropertyOrder({
+    "tableId", "part", "schema", "keyMapping", "filter", "selection", "indexId", "indexRegionId"
+})
+public class TxnDiskAnnResetParam extends FilterProjectSourceParam {
+    private KeyValueCodec codec;
+    private final Table table;
+
+    private final NavigableMap<ByteArrayUtils.ComparableByteArray, RangeDistribution> distributions;
+    private final CommonId indexId;
+    private final IndexTable indexTable;
+    @JsonProperty("scanTs")
+    private long scanTs;
+    @JsonProperty("filter")
+    protected SqlExpr filter;
+    @JsonProperty("isolationLevel")
+    private final int isolationLevel;
+    @JsonProperty("timeOut")
+    private final long timeOut;
+    @JsonProperty("selection")
+    protected TupleMapping selection;
+
+    public TxnDiskAnnResetParam(
+        CommonId partId,
+        SqlExpr filter,
+        TupleMapping selection,
+        DingoType schema,
+        Table table,
+        NavigableMap<ByteArrayUtils.ComparableByteArray, RangeDistribution> distributions,
+        Table indexTable,
+        long scanTs,
+        int isolationLevel,
+        long timeOut
+    ) {
+        super(table.tableId, partId, schema, table.version, filter, selection, table.keyMapping());
+        this.table = table;
+        this.distributions = distributions;
+        this.indexId = indexTable.tableId;
+        this.indexTable = (IndexTable) indexTable;
+        this.scanTs = scanTs;
+        this.isolationLevel = isolationLevel;
+        this.timeOut = timeOut;
+    }
+
+    @Override
+    public void init(Vertex vertex) {
+        super.init(vertex);
+        codec = CodecService.getDefault().createKeyValueCodec(schemaVersion, schema, keyMapping);
+    }
+
+    @Override
+    public void setStartTs(long startTs) {
+        this.scanTs = startTs;
+    }
+
+}

--- a/dingo-exec/src/main/java/io/dingodb/exec/operator/params/TxnDiskAnnStatusParam.java
+++ b/dingo-exec/src/main/java/io/dingodb/exec/operator/params/TxnDiskAnnStatusParam.java
@@ -1,0 +1,95 @@
+/*
+ * Copyright 2021 DataCanvas
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package io.dingodb.exec.operator.params;
+
+import com.fasterxml.jackson.annotation.JsonProperty;
+import com.fasterxml.jackson.annotation.JsonPropertyOrder;
+import com.fasterxml.jackson.annotation.JsonTypeName;
+import io.dingodb.codec.CodecService;
+import io.dingodb.codec.KeyValueCodec;
+import io.dingodb.common.CommonId;
+import io.dingodb.common.partition.RangeDistribution;
+import io.dingodb.common.type.DingoType;
+import io.dingodb.common.type.TupleMapping;
+import io.dingodb.common.util.ByteArrayUtils;
+import io.dingodb.exec.dag.Vertex;
+import io.dingodb.exec.expr.SqlExpr;
+import io.dingodb.expr.rel.RelOp;
+import io.dingodb.meta.entity.IndexTable;
+import io.dingodb.meta.entity.Table;
+import lombok.Getter;
+
+import java.util.Map;
+import java.util.NavigableMap;
+
+@Getter
+@JsonTypeName("txn_diskAnnStatus")
+@JsonPropertyOrder({
+    "tableId", "part", "schema", "keyMapping", "filter", "selection", "indexId", "indexRegionId"
+})
+public class TxnDiskAnnStatusParam extends FilterProjectSourceParam {
+    private KeyValueCodec codec;
+    private final Table table;
+
+    private final NavigableMap<ByteArrayUtils.ComparableByteArray, RangeDistribution> distributions;
+    private final CommonId indexId;
+    private final IndexTable indexTable;
+    @JsonProperty("scanTs")
+    private long scanTs;
+    @JsonProperty("filter")
+    protected SqlExpr filter;
+    @JsonProperty("isolationLevel")
+    private final int isolationLevel;
+    @JsonProperty("timeOut")
+    private final long timeOut;
+    @JsonProperty("selection")
+    protected TupleMapping selection;
+
+    public TxnDiskAnnStatusParam(
+        CommonId partId,
+        SqlExpr filter,
+        TupleMapping selection,
+        DingoType schema,
+        Table table,
+        NavigableMap<ByteArrayUtils.ComparableByteArray, RangeDistribution> distributions,
+        Table indexTable,
+        long scanTs,
+        int isolationLevel,
+        long timeOut
+    ) {
+        super(table.tableId, partId, schema, table.version, filter, selection, table.keyMapping());
+        this.table = table;
+        this.distributions = distributions;
+        this.indexId = indexTable.tableId;
+        this.indexTable = (IndexTable) indexTable;
+        this.scanTs = scanTs;
+        this.isolationLevel = isolationLevel;
+        this.timeOut = timeOut;
+    }
+
+    @Override
+    public void init(Vertex vertex) {
+        super.init(vertex);
+        codec = CodecService.getDefault().createKeyValueCodec(schemaVersion, schema, keyMapping);
+    }
+
+    @Override
+    public void setStartTs(long startTs) {
+        this.scanTs = startTs;
+    }
+
+}

--- a/dingo-exec/src/main/java/io/dingodb/exec/operator/params/TxnPartVectorParam.java
+++ b/dingo-exec/src/main/java/io/dingodb/exec/operator/params/TxnPartVectorParam.java
@@ -39,6 +39,7 @@ import io.dingodb.expr.rel.RelOp;
 import io.dingodb.expr.runtime.type.TupleType;
 import io.dingodb.meta.entity.Column;
 import io.dingodb.meta.entity.IndexTable;
+import io.dingodb.meta.entity.IndexType;
 import io.dingodb.meta.entity.Table;
 import lombok.Getter;
 
@@ -182,4 +183,7 @@ public class TxnPartVectorParam extends FilterProjectSourceParam {
         return TupleMapping.of(Arrays.copyOf(mappings, keyCount));
     }
 
+    public boolean isDiskAnnVector() {
+        return indexTable.getIndexType() == IndexType.VECTOR_DISKANN;
+    }
 }

--- a/dingo-exec/src/main/java/io/dingodb/exec/transaction/util/TimeUtils.java
+++ b/dingo-exec/src/main/java/io/dingodb/exec/transaction/util/TimeUtils.java
@@ -1,0 +1,33 @@
+/*
+ * Copyright 2021 DataCanvas
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package io.dingodb.exec.transaction.util;
+
+import java.sql.Timestamp;
+import java.time.Instant;
+import java.time.ZoneId;
+import java.time.ZonedDateTime;
+import java.time.format.DateTimeFormatter;
+
+public class TimeUtils {
+    public static final String FORMAT = "yyyy-MM-dd'T'HH:mm:ss'Z'";
+    public static String to(Timestamp timestamp) {
+        Instant instant = timestamp.toInstant();
+        ZonedDateTime zonedDateTime = instant.atZone(ZoneId.of("UTC+8"));
+        DateTimeFormatter formatter = DateTimeFormatter.ofPattern(FORMAT);
+        return zonedDateTime.format(formatter);
+    }
+}

--- a/dingo-exec/src/main/java/io/dingodb/exec/transaction/util/TransactionCacheToMutation.java
+++ b/dingo-exec/src/main/java/io/dingodb/exec/transaction/util/TransactionCacheToMutation.java
@@ -28,8 +28,10 @@ import io.dingodb.common.type.DingoTypeFactory;
 import io.dingodb.common.type.TupleMapping;
 import io.dingodb.common.type.TupleType;
 import io.dingodb.common.type.scalar.BinaryType;
+import io.dingodb.common.type.scalar.BooleanType;
 import io.dingodb.common.type.scalar.DoubleType;
 import io.dingodb.common.type.scalar.LongType;
+import io.dingodb.common.type.scalar.TimestampType;
 import io.dingodb.common.util.Optional;
 import io.dingodb.exec.Services;
 import io.dingodb.exec.transaction.base.TransactionType;
@@ -56,9 +58,9 @@ import lombok.extern.slf4j.Slf4j;
 import org.checkerframework.checker.nullness.qual.NonNull;
 import org.checkerframework.checker.nullness.qual.Nullable;
 
+import java.sql.Timestamp;
 import java.util.Collections;
 import java.util.HashMap;
-import java.util.Iterator;
 import java.util.List;
 import java.util.Map;
 import java.util.stream.Collectors;
@@ -153,6 +155,14 @@ public final class TransactionCacheToMutation {
                     } else if (type instanceof DoubleType) {
                         Double data = (Double) record[colNames.indexOf(columnDef.getName())];
                         fieldType = DocumentValue.ScalarFieldType.DOUBLE;
+                        scalarField = new ScalarField(data);
+                    } else if (type instanceof TimestampType) {
+                        Timestamp data = (Timestamp) record[colNames.indexOf(columnDef.getName())];
+                        fieldType = DocumentValue.ScalarFieldType.DATETIME;
+                        scalarField = new ScalarField(TimeUtils.to(data));
+                    } else if (type instanceof BooleanType) {
+                        Boolean data = (Boolean) record[colNames.indexOf(columnDef.getName())];
+                        fieldType = DocumentValue.ScalarFieldType.BOOL;
                         scalarField = new ScalarField(data);
                     } else {
                         String data = (String) record[colNames.indexOf(columnDef.getName())];

--- a/dingo-exec/src/main/java/io/dingodb/exec/utils/OperatorCodeUtils.java
+++ b/dingo-exec/src/main/java/io/dingodb/exec/utils/OperatorCodeUtils.java
@@ -111,6 +111,14 @@ public final class OperatorCodeUtils {
     public static final CommonId DOCUMENT_PARTITION = new CommonId(CommonId.CommonType.OP, OP, 90);
     public static final CommonId DOCUMENT_PRE_FILTER = new CommonId(CommonId.CommonType.OP, OP, 91);
 
+    public static final CommonId TXN_DISK_ANN_STATUS = new CommonId(CommonId.CommonType.OP, SOURCE, 92);
+
+    public static final CommonId TXN_DISK_ANN_COUNT_MEMORY = new CommonId(CommonId.CommonType.OP, SOURCE, 93);
+
+    public static final CommonId TXN_DISK_ANN_RESET = new CommonId(CommonId.CommonType.OP, SOURCE, 94);
+    public static final CommonId TXN_DISK_ANN_BUILD = new CommonId(CommonId.CommonType.OP, SOURCE, 95);
+
+    public static final CommonId TXN_DISK_ANN_LOAD = new CommonId(CommonId.CommonType.OP, SOURCE, 96);
     private OperatorCodeUtils() {
     }
 }

--- a/dingo-store-api/src/main/java/io/dingodb/store/api/StoreInstance.java
+++ b/dingo-store-api/src/main/java/io/dingodb/store/api/StoreInstance.java
@@ -20,6 +20,7 @@ import io.dingodb.common.CommonId;
 import io.dingodb.common.Coprocessor;
 import io.dingodb.common.CoprocessorV2;
 import io.dingodb.common.store.KeyValue;
+import io.dingodb.common.util.Pair;
 import io.dingodb.common.vector.VectorSearchResponse;
 import io.dingodb.store.api.transaction.data.DocumentSearchParameter;
 import io.dingodb.store.api.transaction.data.commit.TxnCommit;
@@ -155,11 +156,20 @@ public interface StoreInstance {
     default List<VectorSearchResponse> vectorSearch(
         CommonId indexId, Float[] floatArray, int topN, Map<String, Object> parameterMap
     ) {
-        return vectorSearch(System.identityHashCode(floatArray), indexId, floatArray, topN, parameterMap, null);
+        return vectorSearch(
+            System.identityHashCode(floatArray),
+            indexId,
+            floatArray,
+            topN,
+            parameterMap,
+            null,
+            false
+        );
     }
 
     default List<VectorSearchResponse> vectorSearch(
-        long requestTs, CommonId indexId, Float[] floatArray, int topN, Map<String, Object> parameterMap, CoprocessorV2 coprocessorV2
+        long requestTs, CommonId indexId, Float[] floatArray, int topN, Map<String, Object> parameterMap,
+        CoprocessorV2 coprocessorV2, boolean isDiskAnn
     ) {
         throw new UnsupportedOperationException();
     }
@@ -172,6 +182,35 @@ public interface StoreInstance {
         throw new UnsupportedOperationException();
     }
 
+    default String diskAnnBuild(
+        long requestTs, CommonId indexId, long ts
+    ) {
+        throw new UnsupportedOperationException();
+    }
+
+    default String diskAnnLoad(
+        long requestTs, CommonId indexId, int nodesCacheNum, boolean warmup
+    ) {
+        throw new UnsupportedOperationException();
+    }
+
+    default String diskAnnStatus(
+        long requestTs, CommonId indexId
+    ) {
+        throw new UnsupportedOperationException();
+    }
+
+    default String diskAnnReset(
+        long requestTs, CommonId indexId
+    ) {
+        throw new UnsupportedOperationException();
+    }
+
+    default long diskAnnCountMemory(
+        long requestTs, CommonId indexId
+    ) {
+        throw new UnsupportedOperationException();
+    }
     @Deprecated
     default long count(Range range) {
         throw new UnsupportedOperationException();

--- a/dingo-store-api/src/main/java/io/dingodb/store/api/transaction/data/DocumentValue.java
+++ b/dingo-store-api/src/main/java/io/dingodb/store/api/transaction/data/DocumentValue.java
@@ -44,7 +44,8 @@ public class DocumentValue {
         FLOAT(6),
         DOUBLE(7),
         STRING(8),
-        BYTES(9);
+        BYTES(9),
+        DATETIME(10);
 
         private final int code;
 

--- a/dingo-store-proxy/src/main/java/io/dingodb/store/proxy/mapper/IndexMapper.java
+++ b/dingo-store-proxy/src/main/java/io/dingodb/store/proxy/mapper/IndexMapper.java
@@ -32,6 +32,7 @@ import io.dingodb.sdk.service.entity.common.ScalarIndexType;
 import io.dingodb.sdk.service.entity.common.ScalarSchema;
 import io.dingodb.sdk.service.entity.common.ScalarSchemaItem;
 import io.dingodb.sdk.service.entity.common.ScalarValue;
+import io.dingodb.sdk.service.entity.common.ValueType;
 import io.dingodb.sdk.service.entity.common.VectorIndexParameter;
 import io.dingodb.sdk.service.entity.common.VectorIndexParameter.VectorIndexParameterNest.DiskannParameter;
 import io.dingodb.sdk.service.entity.common.VectorIndexParameter.VectorIndexParameterNest.FlatParameter;
@@ -228,10 +229,19 @@ public interface IndexMapper {
             }
             switch (properties.getOrDefault("type", "HNSW").toUpperCase()) {
                 case "DISKANN":
+                    int maxDegree = Integer.parseInt(properties.getOrDefault("max_degree", "64"));
+                    int searchListSize = Integer.parseInt(properties.getOrDefault("search_list_size", "100"));
                     vectorIndexParameter = VectorIndexParameter.builder()
                         .vectorIndexType(VectorIndexType.VECTOR_INDEX_TYPE_DISKANN)
                         .vectorIndexParameter(
-                            DiskannParameter.builder().dimension(dimension).metricType(metricType).build()
+                            DiskannParameter.builder()
+                                .dimension(dimension)
+                                .metricType(metricType)
+                                .maxDegree(maxDegree)
+                                .searchListSize(searchListSize)
+                                .valueType(ValueType.FLOAT)
+                                .codebookPrefix("")
+                                .build()
                         )
                         .build();
                     break;

--- a/dingo-store-proxy/src/main/java/io/dingodb/store/proxy/mapper/IndexMapper.java
+++ b/dingo-store-proxy/src/main/java/io/dingodb/store/proxy/mapper/IndexMapper.java
@@ -178,6 +178,12 @@ public interface IndexMapper {
                         case "bytes":
                             scalarFieldType = ScalarFieldType.BYTES;
                             break;
+                        case "datetime":
+                            scalarFieldType = ScalarFieldType.DATETIME;
+                            break;
+                        case "bool":
+                            scalarFieldType = ScalarFieldType.BOOL;
+                            break;
                         default:
                             throw new IllegalStateException("Unsupported type: " + type);
                     }
@@ -312,6 +318,10 @@ public interface IndexMapper {
                 return tantivyType.equals("F64");
             case "BYTES":
                 return tantivyType.equals("BYTES");
+            case "TIMESTAMP":
+                return tantivyType.equals("DATETIME");
+            case "BOOLEAN":
+                return tantivyType.equals("BOOL");
             default:
                 throw new IllegalStateException("Unexpected value: " + tantivyType);
         }

--- a/dingo-store-proxy/src/main/java/io/dingodb/store/proxy/mapper/TxnMapper.java
+++ b/dingo-store-proxy/src/main/java/io/dingodb/store/proxy/mapper/TxnMapper.java
@@ -97,7 +97,7 @@ public interface TxnMapper {
                 .fieldValue(scalarFieldTo(documentValue.getFieldValue()))
                 .build();
         }
-        return  res;
+        return res;
     }
 
     default io.dingodb.sdk.service.entity.common.DocumentValue documentValueTo(DocumentValue documentValue) {
@@ -125,6 +125,8 @@ public interface TxnMapper {
                 return DocumentValue.ScalarFieldType.STRING;
             case BYTES:
                 return DocumentValue.ScalarFieldType.BYTES;
+            case DATETIME:
+                return DocumentValue.ScalarFieldType.DATETIME;
             default:
                 throw new IllegalStateException("Unexpected value: " + scalarFieldType);
         }
@@ -146,6 +148,8 @@ public interface TxnMapper {
                 return ScalarFieldType.STRING;
             case BYTES:
                 return ScalarFieldType.BYTES;
+            case DATETIME:
+                return ScalarFieldType.DATETIME;
             default:
                 throw new IllegalStateException("Unexpected value: " + fieldType);
         }
@@ -183,6 +187,10 @@ public interface TxnMapper {
                 return io.dingodb.store.api.transaction.data.ScalarField.builder()
                     .data(((ScalarField.DataNest.BytesData) field.getData()).getValue())
                     .build();
+            case DATETIME_DATA:
+                return io.dingodb.store.api.transaction.data.ScalarField.builder()
+                    .data(((ScalarField.DataNest.DatetimeData) field.getData()).getValue())
+                    .build();
             default:
                 throw new IllegalStateException("Unexpected value: " + field.getData().nest());
         }
@@ -207,6 +215,8 @@ public interface TxnMapper {
                 return ScalarField.builder().data(ScalarField.DataNest.StringData.of((String) field.getData())).build();
             case BYTES:
                 return ScalarField.builder().data(ScalarField.DataNest.BytesData.of((byte[]) field.getData())).build();
+            case DATETIME:
+                return ScalarField.builder().data(ScalarField.DataNest.DatetimeData.of((String) field.getData())).build();
             default:
                 throw new IllegalStateException("Unexpected value: " + type);
         }


### PR DESCRIPTION
[feature][dingo-executor] Support document index datetime and bool type
mysql> select description, birthday, create_time, update_time, is_delete from text_search(test, text_index, 'is_delete:true', 5) order by id;
+---------------------+------------+-------------+-----------------------+-----------+
| description         | birthday   | create_time | update_time           | is_delete |
+---------------------+------------+-------------+-----------------------+-----------+
| Plastic Keyboard    | 1998-04-06 | 08:10:10    | 2022-04-08 18:05:07.0 |         1 |
| Sleek running shoes | 2014-10-13 | 01:00:00    | 1999-12-31 23:59:59.0 |         1 |
+---------------------+------------+-------------+-----------------------+-----------+
2 rows in set (0.19 sec)

mysql> select description, birthday, create_time, update_time, is_delete from text_search(test, text_index, 'update_time:[1999-12-31T23:59:59Z TO 2022-04-08T18:05:07Z]', 5) order by id;
+--------------------------+------------+-------------+-----------------------+-----------+
| description              | birthday   | create_time | update_time           | is_delete |
+--------------------------+------------+-------------+-----------------------+-----------+
| Plastic Keyboard         | 1998-04-06 | 08:10:10    | 2022-04-08 18:05:07.0 |         1 |
| Ergonomic metal keyboard | 1988-02-05 | 06:15:08    | 2000-02-29 00:00:00.0 |         0 |
| Sleek running shoes      | 2014-10-13 | 01:00:00    | 1999-12-31 23:59:59.0 |         1 |
+--------------------------+------------+-------------+-----------------------+-----------+
3 rows in set (0.25 sec)

mysql> select * from hybrid_search(
    -> text_search(test, text_index, 'update_time:"2022-04-08T18:05:07Z"', 5),
    -> vector(test, feature, array[0.8894774317741394, 0.7277960181236267, 0.692345142364502, 0.47235092520713806, 0.8568729162216187, 0.6647433042526245, 0.3333759307861328, 0.5181455016136169], 5),
    -> 0.9,
    -> 0.1
    -> );
+------+-------------+
| ID   | RANK_HYBRID |
+------+-------------+
|    2 |         0.0 |
|    4 | 0.062064737 |
|    1 |   1.1572088 |
|    3 |         0.1 |
+------+-------------+
4 rows in set (0.79 sec)


mysql> CREATE TABLE test (        id bigint not null,        feature float array not null,        feature_id bigint not null,        diskann_id bigint not null,        description varchar not null,        category varchar not null,        rating bigint not null,        text_id bigint not null,        INDEX text_index TEXT(text_id, description, category, rating) engine=TXN_BTREE PARTITION BY RANGE values(10) parameters(text_fields='{"description": {"tokenizer": {"type": "stem"}}, "category": {"tokenizer": {"type": "stem"}}, "rating": {"tokenizer": {"type": "i64"}}, "text_id": {"tokenizer": {"type": "i64"}}}'),        index diskann_index vector(diskann_id, feature) PARTITION BY RANGE values(2) parameters(type=diskann, metricType=L2, dimension=8, max_degree=64, search_list_size=100),        primary key(id) ) engine=TXN_LSM;                                                                                        Query OK, 0 rows affected (1.90 sec)

mysql> insert into test values (1, array[0.19151945412158966, 0.6221087574958801, 0.43772774934768677, 0.7853586077690125, 0.7799758315086365, 0.27259260416030884, 0.2764642536640167, 0.801872193813324], 1, 1, 'Plastic Keyboard', 'Electronics', 4, 1),(2, array[0.959139347076416, 0.8759326338768005, 0.35781726241111755, 0.5009950995445251, 0.683462917804718, 0.7127020359039307, 0.37025076150894165, 0.5611962080001831], 2 , 2, 'Ergonomic metal keyboard', 'Electronics', 4, 2), (3, array[0.5050831437110901, 0.013768449425697327, 0.772826611995697, 0.8826411962509155, 0.36488598585128784, 0.6153962016105652, 0.07538124173879623, 0.3688240051269531], 3, 3, 'Sleek running shoes', 'Footwear', 5, 3), (4, array[0.9361401200294495, 0.6513781547546387, 0.39720258116722107, 0.7887301445007324, 0.3168361186981201, 0.5680986642837524, 0.8691273927688599, 0.4361734092235565], 4, 4, 'Plastic Keyboard', 'Electronics', 4, 4); 
Query OK, 4 rows affected (0.79 sec)

mysql> select * from disk_ann_build(test, diskann_index, 0);
+------------------------+----------------------+
| DISKANN_INDEX$REGIONID | DISKANN_INDEX$STATUS |
+------------------------+----------------------+
|                  80050 | BUILDING             |
|                  80051 | BUILDING             |
+------------------------+----------------------+
2 rows in set (0.13 sec)

mysql> select * from disk_ann_status(test, diskann_index);
+------------------------+----------------------+
| DISKANN_INDEX$REGIONID | DISKANN_INDEX$STATUS |
+------------------------+----------------------+
|                  80051 | UPDATEDPATH          |
|                  80050 | NODATA               |
+------------------------+----------------------+
2 rows in set (0.12 sec)

mysql> select * from disk_ann_load(test, diskann_index, 2, true);
ERROR 5001 (45000): io.dingodb.sdk.common.DingoClientException$RequestErrorException: DiskANN is no data
mysql> select * from disk_ann_load(test, diskann_index, 2, true, 80051);
+------------------------+----------------------+
| DISKANN_INDEX$REGIONID | DISKANN_INDEX$STATUS |
+------------------------+----------------------+
|                  80051 | LOADED               |
+------------------------+----------------------+
1 row in set (0.14 sec)

mysql> 
mysql> select * from disk_ann_status(test, diskann_index);
+------------------------+----------------------+
| DISKANN_INDEX$REGIONID | DISKANN_INDEX$STATUS |
+------------------------+----------------------+
|                  80050 | NODATA               |
|                  80051 | LOADED               |
+------------------------+----------------------+
2 rows in set (0.13 sec)

mysql> select * from vector(test, feature, array[0.8894774317741394, 0.7277960181236267, 0.692345142364502, 0.47235092520713806, 0.8568729162216187, 0.6647433042526245, 0.3333759307861328, 0.5181455016136169], 5);
+------+-----------------------------------------------------------------------------------------------+------------+------------+--------------------------+-------------+--------+---------+------------------------+
| ID   | FEATURE                                                                                       | FEATURE_ID | DISKANN_ID | DESCRIPTION              | CATEGORY    | RATING | TEXT_ID | DISKANN_INDEX$DISTANCE |
+------+-----------------------------------------------------------------------------------------------+------------+------------+--------------------------+-------------+--------+---------+------------------------+
|    1 | [0.19151945, 0.62210876, 0.43772775, 0.7853586, 0.77997583, 0.2725926, 0.27646425, 0.8018722] |          1 |          1 | Plastic Keyboard         | Electronics |      4 |       1 |             0.90455407 |
|    2 | [0.95913935, 0.87593263, 0.35781726, 0.5009951, 0.6834629, 0.71270204, 0.37025076, 0.5611962] |          2 |          2 | Ergonomic metal keyboard | Electronics |      4 |       2 |             0.17511082 |
|    4 | [0.9361401, 0.65137815, 0.39720258, 0.78873014, 0.31683612, 0.56809866, 0.8691274, 0.4361734] |          4 |          4 | Plastic Keyboard         | Electronics |      4 |       4 |               0.789951 |
|    3 | [0.50508314, 0.013768449, 0.7728266, 0.8826412, 0.364886, 0.6153962, 0.07538124, 0.368824]    |          3 |          3 | Sleek running shoes      | Footwear    |      5 |       3 |              1.1657542 |
+------+-----------------------------------------------------------------------------------------------+------------+------------+--------------------------+-------------+--------+---------+------------------------+
4 rows in set (0.45 sec)

mysql>