### PR TITLE
[fix][dingo-executor] Add check for rename table

### DIFF
--- a/dingo-calcite/src/main/java/io/dingodb/calcite/DingoDdlExecutor.java
+++ b/dingo-calcite/src/main/java/io/dingodb/calcite/DingoDdlExecutor.java
@@ -191,6 +191,7 @@ import static io.dingodb.common.ddl.FieldTypeChecker.checkModifyTypeCompatible;
 import static io.dingodb.common.mysql.error.ErrorCode.ErrDropPartitionNonExistent;
 import static io.dingodb.common.mysql.error.ErrorCode.ErrKeyDoesNotExist;
 import static io.dingodb.common.mysql.error.ErrorCode.ErrModifyColumnNotTran;
+import static io.dingodb.common.mysql.error.ErrorCode.ErrNoSuchTable;
 import static io.dingodb.common.mysql.error.ErrorCode.ErrNotFoundDropSchema;
 import static io.dingodb.common.mysql.error.ErrorCode.ErrNotFoundDropTable;
 import static io.dingodb.common.mysql.error.ErrorCode.ErrPartitionMgmtOnNonpartitioned;
@@ -560,6 +561,9 @@ public class DingoDdlExecutor extends DdlExecutorImpl {
                 throw DINGO_RESOURCE.unknownTable(schema.getSchemaName() + "." + tableName).ex();
             }
         }
+        if ("VIEW".equalsIgnoreCase(table.getTableType())) {
+            throw DingoErrUtil.newStdErr(ErrNoSuchTable, tableName);
+        }
         DdlService ddlService = DdlService.root();
         String connId = (String) context.getDataContext().get("connId");
         ddlService.dropTable(schemaInfo, table.tableId.seq, tableName, connId);
@@ -603,6 +607,9 @@ public class DingoDdlExecutor extends DdlExecutorImpl {
                 throw DINGO_RESOURCE.unknownTable(schema.getSchemaName() + "." + tableName).ex();
             }
         }
+        if (!"VIEW".equalsIgnoreCase(table.getTableType())) {
+            throw DingoErrUtil.newStdErrWithMsg("View '%s' do not exist", ErrNoSuchTable, tableName);
+        }
         DdlService ddlService = DdlService.root();
         ddlService.dropTable(schemaInfo, table.tableId.seq, tableName, connId);
 
@@ -636,6 +643,9 @@ public class DingoDdlExecutor extends DdlExecutorImpl {
         String tableName = Parameters.nonNull(schemaTableName.right, "table name").toUpperCase();
         Table table = schema.getTableInfo(tableName);
         if (table == null) {
+            throw DINGO_RESOURCE.tableNotExists(tableName).ex();
+        }
+        if ("VIEW".equalsIgnoreCase(table.getTableType())) {
             throw DINGO_RESOURCE.tableNotExists(tableName).ex();
         }
         DdlService ddlService = DdlService.root();
@@ -1689,26 +1699,34 @@ public class DingoDdlExecutor extends DdlExecutorImpl {
 
     public void execute(SqlAlterRenameTable sqlAlterRenameTable, CalcitePrepare.Context context) {
         LogUtils.info(log, sqlAlterRenameTable.toString());
-        final Pair<SubSnapshotSchema, String> schemaTableName
-            = getSchemaAndTableName(sqlAlterRenameTable.originIdList.get(0), context);
-        final String tableName = Parameters.nonNull(schemaTableName.right, "table name");
-        final SubSnapshotSchema schema = Parameters.nonNull(schemaTableName.left, "table schema");
-        Table table = schema.getTableInfo(tableName);
-        if (table == null) {
-            throw DINGO_RESOURCE.tableNotExists(tableName).ex();
+
+        checkRenameTable(sqlAlterRenameTable, context);
+
+        for (int i = 0; i < sqlAlterRenameTable.originIdList.size(); i ++) {
+            SqlIdentifier originId = sqlAlterRenameTable.originIdList.get(i);
+            SqlIdentifier toId = sqlAlterRenameTable.toIdList.get(i);
+            final Pair<SubSnapshotSchema, String> schemaTableName
+                = getSchemaAndTableName(originId, context);
+            final String tableName = Parameters.nonNull(schemaTableName.right, "table name");
+            final SubSnapshotSchema schema = Parameters.nonNull(schemaTableName.left, "table schema");
+
+            Table table = schema.getTableInfo(tableName);
+            if (table == null) {
+                throw DINGO_RESOURCE.tableNotExists(tableName).ex();
+            }
+            DdlService.root().renameTable(
+                schema.getSchemaId(), schema.getSchemaName(), table,
+                getTableName(toId));
+            RootCalciteSchema rootCalciteSchema = (RootCalciteSchema) context.getMutableRootSchema();
+            RootSnapshotSchema rootSnapshotSchema = (RootSnapshotSchema) rootCalciteSchema.schema;
+            SchemaDiff diff = SchemaDiff.builder()
+                .schemaId(schema.getSchemaId())
+                .tableId(table.getTableId().seq)
+                .type(ActionType.ActionRenameTable)
+                .build();
+            diff.setTableName(tableName);
+            rootSnapshotSchema.applyDiff(diff);
         }
-        DdlService.root().renameTable(
-            schema.getSchemaId(), schema.getSchemaName(), table,
-            getTableName(sqlAlterRenameTable.toIdList.get(0)));
-        RootCalciteSchema rootCalciteSchema = (RootCalciteSchema) context.getMutableRootSchema();
-        RootSnapshotSchema rootSnapshotSchema = (RootSnapshotSchema) rootCalciteSchema.schema;
-        SchemaDiff diff = SchemaDiff.builder()
-            .schemaId(schema.getSchemaId())
-            .tableId(table.getTableId().seq)
-            .type(ActionType.ActionRenameTable)
-            .build();
-        diff.setTableName(tableName);
-        rootSnapshotSchema.applyDiff(diff);
     }
 
     public void execute(SqlAlterRenameIndex sqlAlterRenameIndex, CalcitePrepare.Context context) {
@@ -2770,6 +2788,29 @@ public class DingoDdlExecutor extends DdlExecutorImpl {
             .name(column.getName())
             .autoIncrement(column.isAutoIncrement())
             .build();
+    }
+
+    public static void checkRenameTable(
+        SqlAlterRenameTable sqlAlterRenameTable, CalcitePrepare.@NonNull Context context
+    ) {
+        for (int i = 0; i < sqlAlterRenameTable.originIdList.size(); i ++) {
+            SqlIdentifier originId = sqlAlterRenameTable.originIdList.get(i);
+            final Pair<SubSnapshotSchema, String> schemaTableName
+                = getSchemaAndTableName(originId, context);
+            final String tableName = Parameters.nonNull(schemaTableName.right, "table name");
+            final SubSnapshotSchema schema = Parameters.nonNull(schemaTableName.left, "table schema");
+
+            Table table = schema.getTableInfo(tableName);
+            if (table == null) {
+                throw DINGO_RESOURCE.tableNotExists(tableName).ex();
+            }
+            SqlIdentifier toId = sqlAlterRenameTable.toIdList.get(i);
+            String toTableName = getTableName(toId);
+            Table toTable = schema.getTableInfo(toTableName);
+            if (toTable != null) {
+                throw DINGO_RESOURCE.tableExists(toTableName).ex();
+            }
+        }
     }
 
 }

--- a/dingo-calcite/src/main/java/io/dingodb/calcite/DingoParser.java
+++ b/dingo-calcite/src/main/java/io/dingodb/calcite/DingoParser.java
@@ -56,6 +56,7 @@ import io.dingodb.calcite.grammar.dql.SqlShow;
 import io.dingodb.calcite.grammar.dql.SqlStartGc;
 import io.dingodb.calcite.meta.DingoRelMetadataProvider;
 import io.dingodb.calcite.program.DecorrelateProgram;
+import io.dingodb.calcite.program.DingoPrograms;
 import io.dingodb.calcite.rel.DingoCost;
 import io.dingodb.calcite.rel.LogicalExportData;
 import io.dingodb.calcite.rel.LogicalForUpdate;
@@ -365,19 +366,17 @@ public class DingoParser {
             }
         }
         final Program program = Programs.ofRules(builder.build());
-        // Seems the only way to prevent rex simplifying in optimization.
-        try (Hook.Closeable ignored = Hook.REL_BUILDER_SIMPLIFY.addThread((Holder<Boolean> h) -> h.set(false))) {
-            Timer.Context timeCtx = DingoMetrics.getTimeContext("decorrelateProgram");
-            Program subQueryProgram = Programs.subQuery(cluster.getMetadataProvider());
-            RelNode relNode1 = subQueryProgram.run(planner, relNode, traitSet, ImmutableList.of(), ImmutableList.of());
+        Timer.Context timeCtx = DingoMetrics.getTimeContext("decorrelateProgram");
 
-            DecorrelateProgram decorrelateProgram = new DecorrelateProgram();
-            RelNode relNode2 = decorrelateProgram.run(
-                planner, relNode1, traitSet, ImmutableList.of(), ImmutableList.of()
-            );
-            timeCtx.stop();
-            return program.run(planner, relNode2, traitSet, ImmutableList.of(), ImmutableList.of());
-        }
+        Program subQueryProgram = DingoPrograms.subQuery(cluster.getMetadataProvider());
+        RelNode relNode1 = subQueryProgram.run(planner, relNode, traitSet, ImmutableList.of(), ImmutableList.of());
+
+        DecorrelateProgram decorrelateProgram = new DecorrelateProgram();
+        RelNode relNode2 = decorrelateProgram.run(
+            planner, relNode1, traitSet, ImmutableList.of(), ImmutableList.of()
+        );
+        timeCtx.stop();
+        return program.run(planner, relNode2, traitSet, ImmutableList.of(), ImmutableList.of());
     }
 
     protected static boolean compatibleMysql(SqlNode sqlNode, PlanProfile planProfile) {

--- a/dingo-calcite/src/main/java/io/dingodb/calcite/DingoParser.java
+++ b/dingo-calcite/src/main/java/io/dingodb/calcite/DingoParser.java
@@ -21,11 +21,22 @@ import com.google.common.collect.ImmutableList;
 import io.dingodb.calcite.executor.Executor;
 import io.dingodb.calcite.executor.SqlToExecutorConverter;
 import io.dingodb.calcite.grammar.ddl.DingoSqlCreateTable;
+import io.dingodb.calcite.grammar.ddl.SqlAdminResetAutoInc;
 import io.dingodb.calcite.grammar.ddl.SqlAdminRollback;
 import io.dingodb.calcite.grammar.ddl.SqlAlterAddColumn;
 import io.dingodb.calcite.grammar.ddl.SqlAlterAddIndex;
+import io.dingodb.calcite.grammar.ddl.SqlAlterAutoIncrement;
+import io.dingodb.calcite.grammar.ddl.SqlAlterChangeColumn;
+import io.dingodb.calcite.grammar.ddl.SqlAlterColumn;
 import io.dingodb.calcite.grammar.ddl.SqlAlterDropColumn;
 import io.dingodb.calcite.grammar.ddl.SqlAlterDropIndex;
+import io.dingodb.calcite.grammar.ddl.SqlAlterDropPart;
+import io.dingodb.calcite.grammar.ddl.SqlAlterExchangePart;
+import io.dingodb.calcite.grammar.ddl.SqlAlterModifyColumn;
+import io.dingodb.calcite.grammar.ddl.SqlAlterRenameIndex;
+import io.dingodb.calcite.grammar.ddl.SqlAlterRenameTable;
+import io.dingodb.calcite.grammar.ddl.SqlAlterTableComment;
+import io.dingodb.calcite.grammar.ddl.SqlAlterTruncatePart;
 import io.dingodb.calcite.grammar.ddl.SqlAnalyze;
 import io.dingodb.calcite.grammar.ddl.SqlBeginTx;
 import io.dingodb.calcite.grammar.ddl.SqlCall;
@@ -33,12 +44,15 @@ import io.dingodb.calcite.grammar.ddl.SqlCommit;
 import io.dingodb.calcite.grammar.ddl.SqlCreateSchema;
 import io.dingodb.calcite.grammar.ddl.SqlCreateUser;
 import io.dingodb.calcite.grammar.ddl.SqlDropUser;
+import io.dingodb.calcite.grammar.ddl.SqlFlashBackSchema;
+import io.dingodb.calcite.grammar.ddl.SqlFlashBackTable;
 import io.dingodb.calcite.grammar.ddl.SqlGrant;
 import io.dingodb.calcite.grammar.ddl.SqlKillConnection;
 import io.dingodb.calcite.grammar.ddl.SqlKillQuery;
 import io.dingodb.calcite.grammar.ddl.SqlLoadData;
 import io.dingodb.calcite.grammar.ddl.SqlLockBlock;
 import io.dingodb.calcite.grammar.ddl.SqlLockTable;
+import io.dingodb.calcite.grammar.ddl.SqlRecoverTable;
 import io.dingodb.calcite.grammar.ddl.SqlRollback;
 import io.dingodb.calcite.grammar.ddl.SqlSetPassword;
 import io.dingodb.calcite.grammar.ddl.SqlTruncate;
@@ -73,7 +87,6 @@ import io.dingodb.common.error.DingoException;
 import io.dingodb.common.log.LogUtils;
 import io.dingodb.common.log.SqlLogUtils;
 import io.dingodb.common.metrics.DingoMetrics;
-import io.dingodb.common.mysql.util.DataTimeUtils;
 import io.dingodb.common.profile.PlanProfile;
 import io.dingodb.common.table.HybridSearchTable;
 import io.dingodb.common.type.TupleMapping;
@@ -97,7 +110,6 @@ import org.apache.calcite.rel.hint.HintPredicate;
 import org.apache.calcite.rel.hint.HintStrategyTable;
 import org.apache.calcite.rel.metadata.ChainedRelMetadataProvider;
 import org.apache.calcite.rex.RexBuilder;
-import org.apache.calcite.runtime.Hook;
 import org.apache.calcite.sql.SqlKind;
 import org.apache.calcite.sql.SqlNode;
 import org.apache.calcite.sql.SqlSetOption;
@@ -110,7 +122,6 @@ import org.apache.calcite.sql.validate.SqlDelegatingConformance;
 import org.apache.calcite.sql2rel.SqlToRelConverter;
 import org.apache.calcite.tools.Program;
 import org.apache.calcite.tools.Programs;
-import org.apache.calcite.util.Holder;
 import org.apache.calcite.util.Pair;
 import org.apache.commons.lang3.StringEscapeUtils;
 import org.apache.commons.lang3.StringUtils;
@@ -467,7 +478,21 @@ public class DingoParser {
             || sqlNode instanceof SqlDropSchema || sqlNode instanceof SqlAlterAddColumn
             || sqlNode instanceof SqlAlterDropColumn || sqlNode instanceof SqlAlterAddIndex
             || sqlNode instanceof SqlAlterDropIndex || sqlNode instanceof SqlCreateUser
-            || sqlNode instanceof SqlDropUser || sqlNode instanceof SqlGrant;
+            || sqlNode instanceof SqlDropUser
+            || sqlNode instanceof SqlGrant
+            || sqlNode instanceof SqlAlterRenameTable
+            || sqlNode instanceof SqlAlterRenameIndex
+            || sqlNode instanceof SqlAlterChangeColumn
+            || sqlNode instanceof SqlAlterModifyColumn
+            || sqlNode instanceof SqlRecoverTable
+            || sqlNode instanceof SqlFlashBackTable
+            || sqlNode instanceof SqlFlashBackSchema
+            || sqlNode instanceof SqlAlterColumn
+            || sqlNode instanceof SqlAlterAutoIncrement
+            || sqlNode instanceof SqlAdminResetAutoInc
+            || sqlNode instanceof SqlAlterTableComment
+            || sqlNode instanceof SqlAlterDropPart
+            || sqlNode instanceof SqlAlterTruncatePart || sqlNode instanceof SqlAlterExchangePart;
     }
 
     public long getGcLifeTime() {

--- a/dingo-calcite/src/main/java/io/dingodb/calcite/executor/ShowCreateTableExecutor.java
+++ b/dingo-calcite/src/main/java/io/dingodb/calcite/executor/ShowCreateTableExecutor.java
@@ -21,6 +21,7 @@ import io.dingodb.calcite.runtime.DingoResource;
 import io.dingodb.common.ddl.DdlUtil;
 import io.dingodb.common.meta.SchemaState;
 import io.dingodb.meta.DdlService;
+import io.dingodb.meta.MetaService;
 import io.dingodb.meta.entity.Column;
 import io.dingodb.meta.entity.IndexTable;
 import io.dingodb.meta.entity.IndexType;
@@ -260,7 +261,14 @@ public class ShowCreateTableExecutor extends QueryExecutor {
         createTableSqlStr.append(" engine=").append(table.getEngine()).append(" ");
         createTableSqlStr.append(" replica=").append(table.getReplica());
         if (table.getComment() != null) {
-            createTableSqlStr.append(" comment=").append(table.getComment());
+            createTableSqlStr.append(" comment=").append("'").append(table.getComment()).append("'");
+        }
+        boolean autoInc = table.getColumns().stream().anyMatch(Column::isAutoIncrement);
+        if (autoInc) {
+            long autoIncVal = MetaService.root().getNextAutoIncrement(table.tableId);
+            if (autoIncVal > 2) {
+                createTableSqlStr.append(" AUTO_INCREMENT=").append(autoIncVal);
+            }
         }
         appendPart(table, createTableSqlStr);
         return createTableSqlStr.toString();

--- a/dingo-calcite/src/main/java/io/dingodb/calcite/grammar/ddl/DingoSqlDdlNodes.java
+++ b/dingo-calcite/src/main/java/io/dingodb/calcite/grammar/ddl/DingoSqlDdlNodes.java
@@ -51,6 +51,9 @@ public class DingoSqlDdlNodes {
         String collate,
         int codecVersion
     ) {
+        if (comment != null) {
+            comment = comment.startsWith("'") ? comment.substring(1, comment.length() - 1) : comment;
+        }
         return new DingoSqlCreateTable(
             pos,
             replace,

--- a/dingo-calcite/src/main/java/io/dingodb/calcite/program/DingoPrograms.java
+++ b/dingo-calcite/src/main/java/io/dingodb/calcite/program/DingoPrograms.java
@@ -1,0 +1,41 @@
+/*
+ * Copyright 2021 DataCanvas
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package io.dingodb.calcite.program;
+
+import com.google.common.collect.ImmutableList;
+import org.apache.calcite.plan.hep.HepPlanner;
+import org.apache.calcite.plan.hep.HepProgram;
+import org.apache.calcite.plan.hep.HepProgramBuilder;
+import org.apache.calcite.rel.RelNode;
+import org.apache.calcite.rel.metadata.RelMetadataProvider;
+import org.apache.calcite.rel.rules.CoreRules;
+import org.apache.calcite.tools.Program;
+import org.apache.calcite.tools.Programs;
+
+public final class DingoPrograms {
+    private DingoPrograms() {
+    }
+
+    public static Program subQuery(RelMetadataProvider metadataProvider) {
+        HepProgramBuilder builder = HepProgram.builder();
+        builder.addRuleCollection(ImmutableList.of(
+            CoreRules.FILTER_SUB_QUERY_TO_CORRELATE, CoreRules.PROJECT_SUB_QUERY_TO_CORRELATE,
+            CoreRules.JOIN_SUB_QUERY_TO_CORRELATE, CoreRules.JOIN_DERIVE_IS_NOT_NULL_FILTER_RULE));
+        return Programs.of(builder.build(), true, metadataProvider);
+    }
+
+}

--- a/dingo-calcite/src/main/java/io/dingodb/calcite/program/DingoPrograms.java
+++ b/dingo-calcite/src/main/java/io/dingodb/calcite/program/DingoPrograms.java
@@ -17,10 +17,8 @@
 package io.dingodb.calcite.program;
 
 import com.google.common.collect.ImmutableList;
-import org.apache.calcite.plan.hep.HepPlanner;
 import org.apache.calcite.plan.hep.HepProgram;
 import org.apache.calcite.plan.hep.HepProgramBuilder;
-import org.apache.calcite.rel.RelNode;
 import org.apache.calcite.rel.metadata.RelMetadataProvider;
 import org.apache.calcite.rel.rules.CoreRules;
 import org.apache.calcite.tools.Program;
@@ -35,7 +33,9 @@ public final class DingoPrograms {
         builder.addRuleCollection(ImmutableList.of(
             CoreRules.FILTER_SUB_QUERY_TO_CORRELATE, CoreRules.PROJECT_SUB_QUERY_TO_CORRELATE,
             CoreRules.JOIN_SUB_QUERY_TO_CORRELATE,
-            CoreRules.JOIN_DERIVE_IS_NOT_NULL_FILTER_RULE, CoreRules.FILTER_INTO_JOIN));
+            CoreRules.JOIN_DERIVE_IS_NOT_NULL_FILTER_RULE
+            //CoreRules.FILTER_INTO_JOIN
+            ));
         return Programs.of(builder.build(), true, metadataProvider);
     }
 

--- a/dingo-calcite/src/main/java/io/dingodb/calcite/program/DingoPrograms.java
+++ b/dingo-calcite/src/main/java/io/dingodb/calcite/program/DingoPrograms.java
@@ -34,7 +34,8 @@ public final class DingoPrograms {
         HepProgramBuilder builder = HepProgram.builder();
         builder.addRuleCollection(ImmutableList.of(
             CoreRules.FILTER_SUB_QUERY_TO_CORRELATE, CoreRules.PROJECT_SUB_QUERY_TO_CORRELATE,
-            CoreRules.JOIN_SUB_QUERY_TO_CORRELATE, CoreRules.JOIN_DERIVE_IS_NOT_NULL_FILTER_RULE));
+            CoreRules.JOIN_SUB_QUERY_TO_CORRELATE,
+            CoreRules.JOIN_DERIVE_IS_NOT_NULL_FILTER_RULE, CoreRules.FILTER_INTO_JOIN));
         return Programs.of(builder.build(), true, metadataProvider);
     }
 

--- a/dingo-common/src/main/java/io/dingodb/common/ddl/DdlJob.java
+++ b/dingo-common/src/main/java/io/dingodb/common/ddl/DdlJob.java
@@ -22,9 +22,9 @@ import com.fasterxml.jackson.databind.ObjectMapper;
 import io.dingodb.common.log.LogUtils;
 import io.dingodb.common.meta.SchemaInfo;
 import io.dingodb.common.meta.SchemaState;
+import io.dingodb.common.mysql.DingoErr;
 import io.dingodb.common.partition.PartitionDetailDefinition;
 import io.dingodb.common.sequence.SequenceDefinition;
-import io.dingodb.common.mysql.DingoErr;
 import io.dingodb.common.table.ColumnDefinition;
 import io.dingodb.common.table.IndexDefinition;
 import io.dingodb.common.table.TableDefinition;
@@ -212,6 +212,9 @@ public class DdlJob {
     public byte[] encode(boolean updateRawArgs) {
         if (updateRawArgs) {
             this.rawArgs = getBytesFromObj(args);
+        }
+        if (this.getDingoErr() != null) {
+            this.dingoErr.encodeError();
         }
         return getBytesFromObj(this);
     }

--- a/dingo-common/src/main/java/io/dingodb/common/mysql/DingoErr.java
+++ b/dingo-common/src/main/java/io/dingodb/common/mysql/DingoErr.java
@@ -16,10 +16,13 @@
 
 package io.dingodb.common.mysql;
 
+import java.util.Base64;
+
 public class DingoErr {
     public int errorCode;
     public String state;
     public String errorMsg;
+    public boolean encodeError;
 
     public DingoErr() {
 
@@ -39,6 +42,20 @@ public class DingoErr {
             errorMsg = String.format(errorMsg, param[0], param[1]);
         } else if (paramCnt == 3) {
             errorMsg = String.format(errorMsg, param[0], param[1], param[2]);
+        }
+    }
+
+    public void encodeError() {
+        if (this.errorMsg != null) {
+            this.errorMsg = Base64.getEncoder().encodeToString(errorMsg.getBytes());
+            this.encodeError = true;
+        }
+    }
+
+    public void decodeError() {
+        if (this.errorMsg != null) {
+            this.errorMsg = new String(Base64.getDecoder().decode(this.errorMsg));
+            this.encodeError = false;
         }
     }
 

--- a/dingo-executor/src/main/java/io/dingodb/server/executor/ddl/DdlWorker.java
+++ b/dingo-executor/src/main/java/io/dingodb/server/executor/ddl/DdlWorker.java
@@ -352,17 +352,18 @@ public class DdlWorker {
             job.setDingoErr(DingoErrUtil.newInternalErr(ErrDBCreateExists, job.getSchemaName()));
             return Pair.of(0L, "The database already exists");
         }
-        SchemaInfo schemaInfoTmp = infoSchemaService.getSchema(schemaInfo.getName());
-        if (schemaInfoTmp != null && schemaInfoTmp.getSchemaState() == SchemaState.SCHEMA_PUBLIC) {
-            job.setState(JobState.jobStateCancelled);
-            job.setDingoErr(DingoErrUtil.newInternalErr(ErrDBCreateExists, job.getSchemaName()));
-            return Pair.of(0L, "The database already exists");
-        }
 
         if (schemaInfo.getSchemaState() == SchemaState.SCHEMA_NONE) {
-            schemaInfo.setSchemaState(SchemaState.SCHEMA_PUBLIC);
-            InfoSchemaService service = InfoSchemaService.root();
-            service.createSchema(schemaId, schemaInfo);
+            synchronized (infoSchemaService) {
+                schemaInfo.setSchemaState(SchemaState.SCHEMA_PUBLIC);
+                SchemaInfo schemaInfoTmp = infoSchemaService.getSchema(schemaInfo.getName());
+                if (schemaInfoTmp != null && schemaInfoTmp.getSchemaState() == SchemaState.SCHEMA_PUBLIC) {
+                    job.setState(JobState.jobStateCancelled);
+                    job.setDingoErr(DingoErrUtil.newInternalErr(ErrDBCreateExists, job.getSchemaName()));
+                    return Pair.of(0L, "The database already exists");
+                }
+                infoSchemaService.createSchema(schemaId, schemaInfo);
+            }
             // finish job
             Pair<Long, String> res = updateSchemaVersion(dc, job);
             if (res.getValue() != null) {
@@ -1815,14 +1816,23 @@ public class DdlWorker {
             job.setState(JobState.jobStateCancelled);
             return Pair.of(0L, error);
         }
-        String toName = job.getArgs().get(0).toString();
-        Pair<TableDefinitionWithId, String> tableRes = checkTableExistAndCancelNonExistJob(job, job.getSchemaId());
-        if (tableRes.getValue() != null && tableRes.getKey() == null) {
-            return Pair.of(0L, tableRes.getValue());
+        synchronized (dc) {
+            io.dingodb.meta.InfoSchemaService service = io.dingodb.meta.InfoSchemaService.root();
+            Object tabObj = service.getTable(job.getSchemaId(), job.getTableName());
+            if (tabObj == null) {
+                job.setState(JobState.jobStateCancelled);
+                job.setDingoErr(DingoErrUtil.newInternalErr(ErrNoSuchTable, job.getTableName()));
+                return Pair.of(0L, job.getDingoErr().errorMsg);
+            }
+            String toName = job.getArgs().get(0).toString();
+            Pair<TableDefinitionWithId, String> tableRes = checkTableExistAndCancelNonExistJob(job, job.getSchemaId());
+            if (tableRes.getValue() != null && tableRes.getKey() == null) {
+                return Pair.of(0L, tableRes.getValue());
+            }
+            tableRes.getKey().getTableDefinition().setName(toName);
+            job.finishTableJob(JobState.jobStateDone, SchemaState.SCHEMA_PUBLIC);
+            return TableUtil.updateVersionAndTableInfos(dc, job, tableRes.getKey(), true);
         }
-        tableRes.getKey().getTableDefinition().setName(toName);
-        job.finishTableJob(JobState.jobStateDone, SchemaState.SCHEMA_PUBLIC);
-        return TableUtil.updateVersionAndTableInfos(dc, job, tableRes.getKey(), true);
     }
 
     public Pair<Long, String> onRenameIndex(DdlContext dc, DdlJob job) {

--- a/dingo-executor/src/main/java/io/dingodb/server/executor/prepare/PrepareMeta.java
+++ b/dingo-executor/src/main/java/io/dingodb/server/executor/prepare/PrepareMeta.java
@@ -75,6 +75,7 @@ public final class PrepareMeta {
 
     public static synchronized void prepare(String coordinators) {
         io.dingodb.meta.InfoSchemaService infoSchemaService = io.dingodb.meta.InfoSchemaService.root();
+        synchronizeTenant();
         if (infoSchemaService.prepareStarted()) {
             return;
         }
@@ -623,6 +624,17 @@ public final class PrepareMeta {
             LogUtils.error(log, "create table failed:{}, schemaName:{}, tableName:{}",
                 e.getMessage(), schema, tableName, e);
         }
+    }
+
+    public static void synchronizeTenant() {
+        List<Object> tenantObjList = io.dingodb.meta.InfoSchemaService.root().listTenant();
+        tenantObjList.forEach(object -> {
+            Tenant tenant = (Tenant) object;
+            if (!MetaService.ROOT.existsTenant(tenant.getId())) {
+                MetaService.ROOT.createTenant(tenant);
+                LogUtils.info(log, "synchronize tenant id to coordinator:{}", tenant.getId());
+            }
+        });
     }
 
     private static boolean continueRetry() {

--- a/dingo-store-proxy/src/main/java/io/dingodb/store/proxy/ddl/DdlHandler.java
+++ b/dingo-store-proxy/src/main/java/io/dingodb/store/proxy/ddl/DdlHandler.java
@@ -562,6 +562,9 @@ public class DdlHandler {
                 String error = ddlJob.decodeError();
                 return Pair.of(false, DingoErrUtil.newInternalErr(error));
             } else {
+                if (ddlJob.getDingoErr().encodeError) {
+                    ddlJob.getDingoErr().decodeError();
+                }
                 return Pair.of(false, ddlJob.getDingoErr());
             }
         }

--- a/dingo-store-proxy/src/main/java/io/dingodb/store/proxy/meta/MetaService.java
+++ b/dingo-store-proxy/src/main/java/io/dingodb/store/proxy/meta/MetaService.java
@@ -22,7 +22,6 @@ import io.dingodb.common.CommonId;
 import io.dingodb.common.concurrent.Executors;
 import io.dingodb.common.ddl.DdlUtil;
 import io.dingodb.common.ddl.GcDeleteRegion;
-import io.dingodb.common.ddl.JobState;
 import io.dingodb.common.log.LogUtils;
 import io.dingodb.common.meta.SchemaInfo;
 import io.dingodb.common.meta.SchemaState;
@@ -91,7 +90,6 @@ import io.dingodb.sdk.service.entity.meta.TableIdWithPartIds;
 import io.dingodb.sdk.service.entity.meta.UpdateTenantRequest;
 import io.dingodb.store.api.StoreInstance;
 import io.dingodb.store.proxy.Configuration;
-import io.dingodb.store.proxy.mapper.Mapper;
 import io.dingodb.store.proxy.service.AutoIncrementService;
 import io.dingodb.store.proxy.service.CodecService;
 import io.dingodb.store.service.InfoSchemaService;
@@ -100,7 +98,6 @@ import lombok.extern.slf4j.Slf4j;
 import org.checkerframework.checker.nullness.qual.NonNull;
 
 import java.util.ArrayList;
-import java.util.Arrays;
 import java.util.Collection;
 import java.util.Collections;
 import java.util.HashMap;
@@ -801,6 +798,23 @@ public class MetaService implements io.dingodb.meta.MetaService {
             .tableId(indexId)
             .partIds(indexPartIds)
             .build();
+        int directReplica = index.getReplica();
+        if (index.getReplica() == 0) {
+            String indexType = index.getProperties().getProperty("indexType", "scalar");
+            int actual;
+            switch (indexType) {
+                case "vector":
+                    actual = io.dingodb.meta.InfoSchemaService.root().getIndexReplica();
+                    break;
+                case "document":
+                    actual = io.dingodb.meta.InfoSchemaService.root().getDocumentReplica();
+                    break;
+                default:
+                    actual = io.dingodb.meta.InfoSchemaService.root().getStoreReplica();
+                    break;
+            }
+            index.setReplica(actual);
+        }
 
         TableDefinitionWithId indexWithId = Stream.of(index)
             .map(i -> {
@@ -816,7 +830,7 @@ public class MetaService implements io.dingodb.meta.MetaService {
             .peek(td -> td.getTableDefinition().setName(tableName + "." + td.getTableDefinition().getName()))
             .findAny().get();
         io.dingodb.meta.InfoSchemaService.root().createIndex(tableId.domain, tableId.seq, indexWithId);
-        createIndexRegion(indexWithId, tableId, index.getReplica());
+        createIndexRegion(indexWithId, tableId, directReplica);
     }
 
     @Override

--- a/dingo-store-proxy/src/main/java/io/dingodb/store/proxy/meta/MetaService.java
+++ b/dingo-store-proxy/src/main/java/io/dingodb/store/proxy/meta/MetaService.java
@@ -81,6 +81,8 @@ import io.dingodb.sdk.service.entity.meta.DropTenantRequest;
 import io.dingodb.sdk.service.entity.meta.EntityType;
 import io.dingodb.sdk.service.entity.meta.GetSchemasRequest;
 import io.dingodb.sdk.service.entity.meta.GetSchemasResponse;
+import io.dingodb.sdk.service.entity.meta.GetTenantsRequest;
+import io.dingodb.sdk.service.entity.meta.GetTenantsResponse;
 import io.dingodb.sdk.service.entity.meta.Partition;
 import io.dingodb.sdk.service.entity.meta.ReservedSchemaIds;
 import io.dingodb.sdk.service.entity.meta.Schema;
@@ -98,6 +100,7 @@ import lombok.extern.slf4j.Slf4j;
 import org.checkerframework.checker.nullness.qual.NonNull;
 
 import java.util.ArrayList;
+import java.util.Arrays;
 import java.util.Collection;
 import java.util.Collections;
 import java.util.HashMap;
@@ -1461,6 +1464,14 @@ public class MetaService implements io.dingodb.meta.MetaService {
             .tenantId(tenantId)
             .build();
         this.service.dropTenant(System.identityHashCode(dropTenantRequest), dropTenantRequest);
+    }
+
+    public boolean existsTenant(long tenantId) {
+        GetTenantsRequest getTenantsRequest = GetTenantsRequest.builder()
+            .tenantIds(Collections.singletonList(tenantId)).build();
+        GetTenantsResponse response = this.service
+            .getTenants(System.identityHashCode(getTenantsRequest), getTenantsRequest);
+        return !response.getTenants().isEmpty();
     }
 
     public static void validatePartBy(TableDefinition tableDefinition) {


### PR DESCRIPTION
example: Add JOIN_DERIVE_IS_NOT_NULL_FILTER_RULE

select t1.* from t1 join t2 on t1.id=t2.tid

join
  scan(t1)
  scan(t2)
-->
join
  filter(t1.id is not null)
    scan(t1)
  filter(t2.tid is not null)
    scan(t2)