### PR TITLE
[fix][dingo-calcite] Support compatible types of decimal and binary

### DIFF
--- a/dingo-calcite/src/main/java/io/dingodb/calcite/type/DingoSqlTypeFactory.java
+++ b/dingo-calcite/src/main/java/io/dingodb/calcite/type/DingoSqlTypeFactory.java
@@ -173,6 +173,12 @@ public class DingoSqlTypeFactory extends JavaTypeFactoryImpl {
                     } else if ((resultType.getSqlTypeName().getName().equalsIgnoreCase("INTEGER")
                         && type.getSqlTypeName().getName().equalsIgnoreCase("BOOLEAN"))) {
                         resultType = type;
+                    } else if (type.getSqlTypeName().getName().equalsIgnoreCase("DECIMAL")
+                        && resultType.getSqlTypeName().getName().equalsIgnoreCase("BINARY")) {
+                        continue;
+                    } else if ((resultType.getSqlTypeName().getName().equalsIgnoreCase("DECIMAL")
+                        && type.getSqlTypeName().getName().equalsIgnoreCase("BINARY"))) {
+                        resultType = type;
                     } else {
                         return null;
                     }


### PR DESCRIPTION
 insert into pack values(1,x'313830302e3030'),(2,null);
 insert into pack values(2,null),(1,x'313830302e3030');
mysql> select * from pack;
+----+---------+
| id | price   |
+----+---------+
|  1 | 1800.00 |
|  2 | NULL    |
|  2 | NULL    |
|  1 | 1800.00 |
+----+---------+