### PR TITLE
[fix][dingo-meta-api] When flashback table is changed to a different …

### DIFF
--- a/dingo-meta-api/src/main/java/io/dingodb/meta/ddl/InfoSchemaBuilder.java
+++ b/dingo-meta-api/src/main/java/io/dingodb/meta/ddl/InfoSchemaBuilder.java
@@ -458,7 +458,11 @@ public class InfoSchemaBuilder {
     }
 
     public Pair<List<Long>, String> applyRecoverTable(SchemaDiff diff) {
-        return applyCreateTable(diff);
+        if (diff != null && diff.getSchemaState() == SchemaState.SCHEMA_PUBLIC) {
+            return applyCreateTable(diff);
+        } else {
+            return Pair.of(null, null);
+        }
     }
 
     public Pair<List<Long>, String> applyRecoverSchema(SchemaDiff diff) {


### PR DESCRIPTION
…table name, the original table name is deleted