### PR TITLE
[fix][dingo-executor] Fixed the issue that cast timestamp of str_to_d…

### DIFF
--- a/dingo-exec/src/main/java/io/dingodb/exec/fun/StrToDateFun.java
+++ b/dingo-exec/src/main/java/io/dingodb/exec/fun/StrToDateFun.java
@@ -286,7 +286,7 @@ public class StrToDateFun extends BinaryOp {
         cal.set(Calendar.YEAR, 1970);
         cal.set(Calendar.MONTH, 0);
         cal.set(Calendar.DAY_OF_MONTH, 1);
-        cal.set(Calendar.HOUR_OF_DAY, 0);
+        cal.set(Calendar.HOUR_OF_DAY, 8);
         cal.set(Calendar.MINUTE, 0);
         cal.set(Calendar.SECOND, 0);
         cal.set(Calendar.MILLISECOND, 0);


### PR DESCRIPTION
[fix][dingo-executor] Fixed the issue that cast timestamp of str_to_date function was 8 hours less